### PR TITLE
RIQ-XXX Fix throttle middleware silent no-op on position updates

### DIFF
--- a/src/store/throttleMiddleware.js
+++ b/src/store/throttleMiddleware.js
@@ -1,40 +1,81 @@
-import { batch } from 'react-redux';
+import { sessionActions } from './session';
+import { devicesActions } from './devices';
 
-const threshold = 3;
-const interval = 1500;
+const threshold = 3; // dispatches per second
+const minInterval = 1500;
+const maxInterval = 30000;
+const scaleFactor = 1000;
+
+const debugMode = process.env.NODE_ENV === 'development';
+const debugLog = (message) => debugMode && console.log(message);
 
 export default () => (next) => {
   const buffer = [];
-  let throttle = false;
+  let throttled = false;
   let counter = 0;
+  let currentInterval = minInterval;
 
-  setInterval(() => {
-    if (throttle) {
-      if (buffer.length < threshold) {
-        throttle = false;
+  const tick = () => {
+    if (throttled) {
+      const start = performance.now();
+
+      const flushed = buffer.splice(0, buffer.length);
+
+      const deviceUpdates = {};
+      const positionUpdates = {};
+
+      flushed.forEach((action) => {
+        if (action.type === devicesActions.update.type) {
+          action.payload.forEach((item) => { deviceUpdates[item.id] = item; });
+        } else if (action.type === sessionActions.updatePositions.type) {
+          action.payload.forEach((item) => { positionUpdates[item.deviceId] = item; });
+        }
+      });
+
+      const mergedDeviceUpdates = Object.values(deviceUpdates);
+      if (mergedDeviceUpdates.length) {
+        next({ type: devicesActions.update.type, payload: mergedDeviceUpdates });
       }
-      if (buffer.length > 0) {
-        const latest = buffer[buffer.length - 1];
-        buffer.length = 0;
-        batch(() => next(latest));
+
+      const mergedPositionUpdates = Object.values(positionUpdates);
+      if (mergedPositionUpdates.length) {
+        next({ type: sessionActions.updatePositions.type, payload: mergedPositionUpdates });
       }
-    } else {
-      if (counter > threshold) {
-        throttle = true;
-      }
-      counter = 0;
+
+      const totalTime = performance.now() - start;
+      debugLog(`Flushed ${mergedDeviceUpdates.length + mergedPositionUpdates.length} / ${flushed.length} events in ${totalTime.toFixed(2)} ms`);
+      currentInterval = Math.min(Math.max(totalTime * scaleFactor, minInterval), maxInterval);
     }
-  }, interval);
+
+    const shouldThrottle = (counter * 1000 / currentInterval) > threshold;
+    if (throttled !== shouldThrottle) {
+      debugLog(`Throttling ${shouldThrottle}`);
+      throttled = shouldThrottle;
+    }
+    counter = 0;
+    if (!throttled) currentInterval = minInterval;
+    setTimeout(tick, currentInterval);
+  };
+
+  setTimeout(tick, currentInterval);
 
   return (action) => {
-    if (action.type === 'devices/update' || action.type === 'positions/update') {
-      if (throttle) {
-        buffer.push(action);
-        return null;
-      }
-      counter += 1;
+    if (action.type !== devicesActions.update.type && action.type !== sessionActions.updatePositions.type) {
       return next(action);
     }
+
+    counter += 1;
+
+    if (throttled) {
+      buffer.push(action);
+      return undefined;
+    }
+
+    if ((counter * 1000 / currentInterval) > threshold) {
+      if (!throttled) debugLog('Throttling started');
+      throttled = true;
+    }
+
     return next(action);
   };
 };


### PR DESCRIPTION
## Summary

Cherry-picks `6a73e3b7` from `lazy_loading_bug_fixing` (with trailing-newline fix) to land the throttle middleware fix on its own, ahead of the lazy-loading work. One file changed, ~80 lines.

## The bug

`src/store/throttleMiddleware.js` line 30 checked for action type `'positions/update'`. **That action type does not exist anywhere in the codebase.**

Position updates are dispatched as `sessionActions.updatePositions(...)` from `SocketController.jsx` (lines 54 and 72). Redux Toolkit generates the action type from the slice name + reducer name, so the real type is `'session/updatePositions'` — not `'positions/update'`.

**Impact:** every position update from the WebSocket bypassed the throttle and dispatched straight to the reducer. For a fleet of 1000 devices reporting every 30 s, that is ~33 unbatched Redux dispatches per second on the hot path, each one re-rendering everything subscribed to `state.session.positions` (map markers, live routes, status card, device list). This is the root cause of the choppy-map-under-load reports.

The `'devices/update'` check on the same line worked correctly (slice name `'devices'` + reducer `update` = action type `'devices/update'`). That asymmetry is why throttling looked like it was working — devices throttled fine, positions never throttled at all.

## The fix

Adopts the upstream `traccar/traccar-web` middleware (commit `b72c8322`). Three structural improvements:

1. **Typed action references** instead of string literals:
   ```js
   if (action.type !== devicesActions.update.type
       && action.type !== sessionActions.updatePositions.type) {
     return next(action);
   }
   ```
   If anyone renames the slice or reducer in future, this fails to resolve at module load — loud build-time error instead of silent perf regression. This prevents the original bug class from recurring.

2. **Adaptive flush interval** (1.5 s–30 s, scales with flush wall-time). Hot servers back off; idle clients flush snappily.

3. **Per-entity deduplication.** During a throttle window, only the latest position per device makes it to the reducer on flush. Trail granularity becomes proportional to actual rendered frames, not raw dispatch frequency.

## What users will notice

- **Smoother map** under load. The 33+ dispatch/sec floor for 1000-device fleets is gone.
- **Reduced CPU and battery use** on dispatcher workstations and tablets.
- **Subtle behavior change in live-route trails**: under heavy load, intermediate positions during a throttle window are not added to the on-map polyline. The trail granularity now matches what the renderer can actually display. At idle load, identical to before.

## Verification

### Reproduce the bug (before this PR)

1. Boot the app against a busy fleet (or a synthetic stream emulating 100+ devices).
2. Open Redux DevTools and filter actions by type.
3. Watch the action stream: `session/updatePositions` actions arrive continuously, often 10–30/sec or more.
4. Console (dev mode): no throttling log lines.

### Confirm the fix

1. Apply this PR and rebuild.
2. Same fleet, same DevTools setup.
3. Console (dev mode) shows `Throttling true` within seconds.
4. Redux action stream: dispatches now arrive at the throttled cadence (every 1.5–30 s) with merged payloads.
5. Console shows `Flushed N / M events in K ms` periodically.

### Perf measurement

DevTools Performance tab, 30 s recording on the main page:
- **Before:** high frequency of `session/updatePositions` commits in the main-thread flame graph.
- **After:** commits clumped at the throttle interval; clean main-thread frames between ticks.

Expected drop in React commits per minute: **5×–50×** depending on fleet size.

### Regression-walk

- **Device selection** — StatusCard still updates when a new position arrives (within 1.5–30 s of arrival).
- **Live route trails** — still draw; with proportionally fewer points under load (documented behavior change).
- **Replay page** — unaffected (reads history endpoints, not the live socket).
- **Manual refresh** — triggers fresh data load as before.

## Risk

Low. Single-file change, no caller / reducer / `package.json` changes. The fork's `session.updatePositions` and `devices.update` reducers already accept array payloads via `forEach`, which is what the new dedup logic emits. No API surface change.

## Rollback

Single-file revert:
```bash
git revert <merge-sha> -- src/store/throttleMiddleware.js
```

## Source

Cherry-picked from `lazy_loading_bug_fixing` commit `6a73e3b7`, with trailing-newline added so ESLint `eol-last` is satisfied. That branch's HEAD still has the lazy-loading work which is being landed separately later.

Full deep-dive (architectural context, why this didn't get caught before): `traccar-web/rides-iq-frontend-throttle-fix-2026-05-21.md`.

## Pre-merge checklist

- [ ] `npm run lint` clean
- [ ] `npm run test:run` clean (vitest infrastructure on release-1 since PR #147)
- [ ] Manual smoke against a busy fleet (or synthetic stream)
- [ ] DevTools Performance recording attached to confirm commit-count drop