### PR TITLE
Fix black map areas: opaque raster background + persisted camera restore

### DIFF
--- a/src/map/core/MapView.jsx
+++ b/src/map/core/MapView.jsx
@@ -6,11 +6,12 @@ import { googleProtocol } from 'maplibre-google-maps';
 import React, {
   useRef, useLayoutEffect, useEffect, useState,
 } from 'react';
+import { useTheme } from '@mui/material/styles';
 import { SwitcherControl } from '../switcher/switcher';
 import { useAttributePreference, usePreference } from '../../common/util/preferences';
 import usePersistedState, { savePersistedState } from '../../common/util/usePersistedState';
 import { mapImages } from './preloadImages';
-import useMapStyles from './useMapStyles';
+import useMapStyles, { mapBackgroundColor } from './useMapStyles';
 import { FullScreenControl } from '../controls/MapFullScreen';
 
 const element = document.createElement('div');
@@ -21,8 +22,47 @@ element.style.boxSizing = 'initial';
 maplibregl.setRTLTextPlugin(mapboxglRtlTextUrl);
 maplibregl.addProtocol('google', googleProtocol);
 
+const initialCamera = (() => {
+  try {
+    const saved = JSON.parse(window.localStorage.getItem('mapCamera'));
+    if (saved
+      && Number.isFinite(saved.longitude) && Math.abs(saved.longitude) <= 180
+      && Number.isFinite(saved.latitude) && Math.abs(saved.latitude) <= 90
+      && Number.isFinite(saved.zoom) && saved.zoom >= 1 && saved.zoom <= 24) {
+      return saved;
+    }
+  } catch (error) {
+    // ignore invalid persisted camera
+  }
+  return null;
+})();
+
+export const hasRestoredCamera = !!initialCamera;
+
 export const map = new maplibregl.Map({
   container: element,
+  ...(initialCamera && {
+    center: [initialCamera.longitude, initialCamera.latitude],
+    zoom: initialCamera.zoom,
+  }),
+});
+
+map.on('moveend', () => {
+  const zoom = map.getZoom();
+  // resize() also fires moveend, so skip the pre-initialization world view to
+  // avoid persisting it before the camera has ever been positioned
+  if (zoom >= 1) {
+    const center = map.getCenter();
+    try {
+      savePersistedState('mapCamera', {
+        longitude: center.lng,
+        latitude: center.lat,
+        zoom,
+      });
+    } catch (error) {
+      // storage failures must not propagate into maplibre event dispatch
+    }
+  }
 });
 
 let ready = false;
@@ -56,6 +96,7 @@ const initMap = async () => {
 const MapView = ({ children }) => {
   const containerEl = useRef(null);
   const switcherRef = useRef(null);
+  const theme = useTheme();
   const [mapReady, setMapReady] = useState(false);
 
   const mapStyles = useMapStyles();
@@ -90,7 +131,7 @@ const MapView = ({ children }) => {
   useEffect(() => {
     if (!switcherRef.current) return;
     const filteredStyles = mapStyles.filter((s) => s.available && activeMapStyles.includes(s.id));
-    const styles = filteredStyles.length ? filteredStyles : mapStyles.filter((s) => s.id === 'osm');
+    const styles = filteredStyles.length ? filteredStyles : mapStyles.filter((s) => s.available);
     switcherRef.current.updateStyles(styles, defaultMapStyle);
   }, [mapStyles, defaultMapStyle, activeMapStyles]);
 
@@ -117,6 +158,13 @@ const MapView = ({ children }) => {
       removeReadyListener(listener);
     };
   }, []);
+
+  useLayoutEffect(() => {
+    // shown where the canvas is transparent (before a style loads and during
+    // style switches); raster tile gaps are covered by each style's own
+    // background layer instead
+    element.style.background = theme.palette.mode === 'dark' ? theme.palette.grey[900] : mapBackgroundColor;
+  }, [theme]);
 
   useLayoutEffect(() => {
     const currentEl = containerEl.current;

--- a/src/map/core/useMapStyles.js
+++ b/src/map/core/useMapStyles.js
@@ -3,6 +3,10 @@ import { useSelector } from 'react-redux';
 import { useTranslation } from '../../common/components/LocalizationProvider';
 import { useAttributePreference } from '../../common/util/preferences';
 
+// Neutral map-like color shown where raster tiles have not loaded yet, so the
+// transparent canvas never exposes the app's dark theme background (#212121).
+export const mapBackgroundColor = '#e8e6e1';
+
 const styleCustom = ({ tiles, minZoom, maxZoom, attribution }) => {
   const source = {
     type: 'raster',
@@ -20,6 +24,12 @@ const styleCustom = ({ tiles, minZoom, maxZoom, attribution }) => {
     },
     glyphs: 'https://api.mapbox.com/fonts/v1/mapbox/{fontstack}/{range}.pbf',
     layers: [{
+      id: 'background',
+      type: 'background',
+      paint: {
+        'background-color': mapBackgroundColor,
+      },
+    }, {
       id: 'custom',
       type: 'raster',
       source: 'custom',
@@ -97,5 +107,5 @@ export default () => {
       available: true,
       attribute: 'googleKey',
     },
-  ], [t, mapTilerKey, locationIqKey, bingMapsKey, tomTomKey, hereKey, mapboxAccessToken, customMapUrl]);
+  ], [t, googleKey, mapTilerKey, locationIqKey, bingMapsKey, tomTomKey, hereKey, mapboxAccessToken, customMapUrl]);
 };

--- a/src/map/main/MapDefaultCamera.js
+++ b/src/map/main/MapDefaultCamera.js
@@ -2,7 +2,7 @@ import maplibregl from 'maplibre-gl';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { usePreference } from '../../common/util/preferences';
-import { map } from '../core/MapView';
+import { map, hasRestoredCamera } from '../core/MapView';
 
 const MapDefaultCamera = ({ mapReady }) => {
   const selectedDeviceId = useSelector((state) => state.devices.selectedId);
@@ -24,6 +24,10 @@ const MapDefaultCamera = ({ mapReady }) => {
           center: [defaultLongitude, defaultLatitude],
           zoom: defaultZoom,
         });
+        setInitialized(true);
+      } else if (hasRestoredCamera) {
+        // Camera was already restored from persisted state when the map was
+        // created, so late position data must not re-fit the whole viewport.
         setInitialized(true);
       } else {
         const coordinates = Object.values(positions).map((item) => [item.longitude, item.latitude]);


### PR DESCRIPTION
## Problem

On the staging deployment, the map showed "black bars" — regions of exactly `#212121` (MUI dark `grey[900]`) — in two situations:

1. **Initial load**: the raster styles built by `styleCustom` had no `background` layer, so wherever a Google tile hadn't arrived yet, the transparent canvas exposed the app's dark theme background.
2. **Camera jump after slow APIs**: `/api/devices` (6.8s) + `/api/positions` (3.8s) resolved long after boot; `MapDefaultCamera` then did a `fitBounds` from zoom 2 to ~16, invalidating every visible tile at once and rendering the whole viewport dark for ~400ms.

## Fix

- **Opaque background layer** (`#e8e6e1`) added inside `styleCustom`, covering all raster presets (Google Road/Satellite/Hybrid). The map container also gets a theme-aware background for the brief pre-style window (neutral in light mode, `grey[900]` in dark so dark vector styles don't get a light flash).
- **Camera persistence**: the camera is saved to `localStorage` (`mapCamera`) on `moveend` and restored in the `Map` constructor, so the very first tile fetch already happens at the user's last view. `MapDefaultCamera` skips fit-to-devices when a camera was restored — the late API response can no longer re-tile the viewport. Explicit default lat/lon preference keeps precedence; first-ever visits keep the fitBounds fallback. Guards: `zoom >= 1` on save/restore (MapLibre `resize()` also fires `moveend`, which would otherwise persist the pre-init world view), value validation, and try/catch around the storage write (maplibre's `Evented.fire` doesn't catch listener exceptions).
- **Latent crash fix**: the style fallback still filtered for the removed `osm` id; with an `activeMapStyles` value matching none of the current styles it threw `TypeError` on `styles[0].id`. Falls back to all available styles instead.
- **Missing `googleKey` dep** added to the `useMapStyles` memo.

## Root cause of the "duplicate tile fetches" in the trace (no code change needed)

The doubled requests (same URL, distinct request IDs, ~0.4ms apart) are **not** a double mount or StrictMode: they're MapLibre `renderWorldCopies`. At zoom 2 the world is 1024px wide, so wider viewports render wrapped world copies; tiles are cached per `(wrap, z, x, y)` but the URL uses canonical z/x/y, so each visible copy fetches the same URL. Reproduced exactly (`mt3 … x=2&y=1&z=2` twice, 0.3ms apart at 1440px width; zero duplicates at 600px). Harmless, and the camera restore eliminates the boot-time world view where it occurs.

## Verification

Ran the production build against a mock backend (2.5s `/api/devices`, 1.5s `/api/positions`) with Fast-4G CDP throttling in headless Chrome, dark mode:

- Unloaded tile areas render `#e8e6e1` instead of near-black (verified with all tile responses delayed 8s).
- Return visits boot directly at the persisted view (~3s to fully rendered map) with **zero camera movement** when positions arrive, vs. world view + full re-tile before. 32 fewer tile requests per return visit.
- `npm run lint` and `npm run build` clean on this branch.

## Follow-up (separate ticket suggested)

The frontend serializes the slow calls: `SocketController` awaits `/api/devices` **before** opening the WebSocket (delaying initial positions), and `DeviceList` fetches `/api/devices` again concurrently at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)