### PR TITLE
Fix release-2 regressions: cluster popup freeze, ghost scrollbar, devices missing at load

### DIFF
--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  Box, Typography, IconButton, Paper, List, ListItem, ListItemText, Divider,
+  Box, Typography, IconButton, Paper, ListItem, ListItemText,
 } from '@mui/material';
+import { FixedSizeList } from 'react-window';
 import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -61,7 +64,6 @@ const useStyles = makeStyles((theme) => ({
   },
   list: {
     overflowY: 'auto',
-    flex: 1,
   },
   listItem: {
     paddingTop: theme.spacing(0.75),
@@ -73,6 +75,48 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const INITIAL_BOTTOM = 16;
+const ROW_HEIGHT = 61;
+const LIST_MAX_HEIGHT = 340;
+
+const ClusterDeviceRow = ({ data, index, style }) => {
+  const { devices, classes, t, onSelect } = data;
+  const device = devices[index];
+  return (
+    <ListItem
+      component="div"
+      dense
+      divider={index < devices.length - 1}
+      style={style}
+      className={classes.listItem}
+      secondaryAction={(
+        <>
+          <IconButton
+            size="small"
+            title={t('sharedShowDetails')}
+            onClick={() => onSelect(device.id)}
+          >
+            <InfoOutlinedIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            title={t('startTracking')}
+            onClick={() => onSelect(device.id)}
+          >
+            <GpsFixedIcon fontSize="small" />
+          </IconButton>
+        </>
+      )}
+    >
+      <ListItemText
+        primary={device.name}
+        secondary={formatStatus(device.status, t)}
+        primaryTypographyProps={{
+          className: classes.deviceName,
+        }}
+      />
+    </ListItem>
+  );
+};
 
 const ClusterPopup = () => {
   const classes = useStyles();
@@ -83,6 +127,15 @@ const ClusterPopup = () => {
   const dragOffset = useRef({ x: 0, y: 0 });
   const [position, setPosition] = useState({ bottom: INITIAL_BOTTOM, left: null, top: null });
   const { visible, devices } = useSelector((state) => state.clusters);
+
+  const handleSelect = useCallback((deviceId) => {
+    dispatch(devicesActions.selectId(deviceId));
+    dispatch(clustersActions.hideClusterPopup());
+  }, [dispatch]);
+
+  const itemData = useMemo(() => ({
+    devices, classes, t, onSelect: handleSelect,
+  }), [devices, classes, t, handleSelect]);
 
   useEffect(() => {
     if (visible) {
@@ -222,49 +275,16 @@ const ClusterPopup = () => {
           <CloseIcon fontSize="small" />
         </IconButton>
       </Box>
-      <List dense disablePadding className={classes.list}>
-        {devices.map((device, index) => (
-          <Box key={device.id}>
-            <ListItem
-              className={classes.listItem}
-              secondaryAction={(
-                <>
-                  <IconButton
-                    size="small"
-                    title={t('sharedShowDetails')}
-                    onClick={() => {
-                      dispatch(devicesActions.selectId(device.id));
-                      dispatch(clustersActions.hideClusterPopup());
-                    }}
-                  >
-                    <InfoOutlinedIcon fontSize="small" />
-                  </IconButton>
-
-                  <IconButton
-                    size="small"
-                    title={t('startTracking')}
-                    onClick={() => {
-                      dispatch(devicesActions.selectId(device.id));
-                      dispatch(clustersActions.hideClusterPopup());
-                    }}
-                  >
-                    <GpsFixedIcon fontSize="small" />
-                  </IconButton>
-                </>
-              )}
-            >
-              <ListItemText
-                primary={device.name}
-                secondary={formatStatus(device.status, t)}
-                primaryTypographyProps={{
-                  className: classes.deviceName,
-                }}
-              />
-            </ListItem>
-            {index < devices.length - 1 && <Divider component="li" />}
-          </Box>
-        ))}
-      </List>
+      <FixedSizeList
+        className={classes.list}
+        height={Math.min(devices.length * ROW_HEIGHT, LIST_MAX_HEIGHT)}
+        width="100%"
+        itemCount={devices.length}
+        itemSize={ROW_HEIGHT}
+        itemData={itemData}
+      >
+        {ClusterDeviceRow}
+      </FixedSizeList>
     </Paper>
   );
 };

--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -65,9 +65,13 @@ const useStyles = makeStyles((theme) => ({
   list: {
     overflowY: 'auto',
     // Styled scrollbars are painted on the main thread instead of composited.
-    // A native composited scrollbar inside this transform/fixed-positioned
-    // popup gets painted at the wrong viewport location by Chromium (ghost
-    // black bar at the top of the map), so never let one be created here.
+    // A native composited scrollbar inside this layer-promoted popup gets
+    // painted at the wrong viewport location by Chromium (ghost black bar at
+    // the top of the map), so never let one be created here. This styling is
+    // the load-bearing fix: react-window keeps the scroller composited via
+    // will-change, so positioning alone cannot prevent the bug. Chromium >=121
+    // uses scrollbar-width/scrollbar-color and ignores the webkit rules, which
+    // remain as the Safari fallback.
     scrollbarWidth: 'thin',
     scrollbarColor: `${theme.palette.grey[500]} transparent`,
     '&::-webkit-scrollbar': {
@@ -127,7 +131,11 @@ const ClusterDeviceRow = ({ data, index, style }) => {
         primary={device.name}
         secondary={formatStatus(device.status, t)}
         primaryTypographyProps={{
+          noWrap: true,
           className: classes.deviceName,
+        }}
+        secondaryTypographyProps={{
+          noWrap: true,
         }}
       />
     </ListItem>
@@ -295,6 +303,7 @@ const ClusterPopup = () => {
       </Box>
       <FixedSizeList
         className={classes.list}
+        style={{ willChange: 'auto' }}
         height={Math.min(devices.length * ROW_HEIGHT, LIST_MAX_HEIGHT)}
         width="100%"
         itemCount={devices.length}

--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -64,6 +64,22 @@ const useStyles = makeStyles((theme) => ({
   },
   list: {
     overflowY: 'auto',
+    // Styled scrollbars are painted on the main thread instead of composited.
+    // A native composited scrollbar inside this transform/fixed-positioned
+    // popup gets painted at the wrong viewport location by Chromium (ghost
+    // black bar at the top of the map), so never let one be created here.
+    scrollbarWidth: 'thin',
+    scrollbarColor: `${theme.palette.grey[500]} transparent`,
+    '&::-webkit-scrollbar': {
+      width: 8,
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: theme.palette.grey[500],
+      borderRadius: 4,
+    },
+    '&::-webkit-scrollbar-track': {
+      background: 'transparent',
+    },
   },
   listItem: {
     paddingTop: theme.spacing(0.75),
@@ -246,7 +262,9 @@ const ClusterPopup = () => {
 
   const style = {
     ...(position.top !== null ? { top: position.top } : { bottom: position.bottom }),
-    ...(position.left !== null ? { left: position.left } : { left: '50%', transform: 'translateX(-50%)' }),
+    // avoid transform positioning: Chromium paints composited scrollbars of
+    // children at the wrong location inside transformed containers
+    ...(position.left !== null ? { left: position.left } : { left: 'calc(50% - 160px)' }),
   };
 
   return (

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -372,7 +372,11 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   useEffect(() => {
     const filtered = positions.filter((p) => Object.prototype.hasOwnProperty.call(devices, p.deviceId));
     updateAnimationState(filtered);
-    if (!enableSmoothing) updateMapData();
+    // Always push current state to the map sources. The animation loop only
+    // runs for devices that moved, so with smoothing enabled the initial
+    // positions would otherwise never reach the sources and no markers or
+    // clusters would render until something else called updateMapData.
+    updateMapData();
   }, [positions, devices, enableSmoothing, updateAnimationState, updateMapData]);
 
   useEffect(() => {

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -335,6 +335,10 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       layout: {
         'icon-image': 'background',
         'icon-size': iconScale,
+        // without allow-overlap, dense areas collision-cull the cluster icon
+        // (large clusters render as bare text and become un-clickable)
+        'icon-allow-overlap': true,
+        'text-allow-overlap': true,
         'text-field': '{point_count_abbreviated}',
         'text-font': findFonts(map),
         'text-size': 14,

--- a/src/map/core/MapView.jsx
+++ b/src/map/core/MapView.jsx
@@ -37,7 +37,7 @@ const initialCamera = (() => {
   return null;
 })();
 
-export const hasRestoredCamera = !!initialCamera;
+export const restoredCamera = initialCamera;
 
 export const map = new maplibregl.Map({
   container: element,

--- a/src/map/main/MapDefaultCamera.js
+++ b/src/map/main/MapDefaultCamera.js
@@ -2,7 +2,13 @@ import maplibregl from 'maplibre-gl';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { usePreference } from '../../common/util/preferences';
-import { map, hasRestoredCamera } from '../core/MapView';
+import { map, restoredCamera } from '../core/MapView';
+
+// A restored camera only suppresses fit-to-devices when it is an actual
+// place the user was looking at; below this zoom it is a world/continent
+// view (e.g. a session that ended before any camera fit), and fitting to
+// the devices is strictly better than restoring it.
+const MIN_RESTORED_ZOOM_TO_SKIP_FIT = 4;
 
 const MapDefaultCamera = ({ mapReady }) => {
   const selectedDeviceId = useSelector((state) => state.devices.selectedId);
@@ -25,7 +31,7 @@ const MapDefaultCamera = ({ mapReady }) => {
           zoom: defaultZoom,
         });
         setInitialized(true);
-      } else if (hasRestoredCamera) {
+      } else if (restoredCamera && restoredCamera.zoom >= MIN_RESTORED_ZOOM_TO_SKIP_FIT) {
         // Camera was already restored from persisted state when the map was
         // created, so late position data must not re-fit the whole viewport.
         setInitialized(true);


### PR DESCRIPTION
Fixes three of the four regressions found in the release-2 performance-trace analysis (the fourth — black unloaded-tile rectangles — was already fixed by #166, which is merged into release-2). Each fix is a separate, minimally-scoped commit.

## Finding 3 — 2.8s main-thread freeze (`Virtualize cluster popup device list`)

The cluster popup rendered every device in a cluster as a plain MUI ListItem. On a dense cluster (~2,400 devices) this produced one ~178,000px-tall layout block and a single ~2.8s task (~14,900 layout invalidations) in production traces — the UI froze from click until the popup appeared. The list now renders through react-window `FixedSizeList` (the same mechanism as the sidebar DeviceList).

**Measured (2,400-device cluster, production build, mock backend):** before: ~1.1s of long tasks on popup open (504+460+106ms on a fast machine; 2.83s single task in the original trace) — after: **zero long tasks**, on open and while scrolling.

## Finding 2 — black ghost scrollbar over the map (`Prevent ghost composited scrollbar…`)

Chromium paints the composited native scrollbar of a scrollable child inside a layer-promoted/transformed container at the wrong viewport location — the popup list's scrollbar rendered as a dark ~15×350px bar at the top of the map, growing on hover (136/136 and 292/292 frames correlation in the traces). Fixed by styling the list scrollbar (`scrollbar-width`/`scrollbar-color` + `::-webkit-scrollbar` as Safari fallback), which forces a Blink-painted scrollbar instead of a composited native one, plus transform-free popup positioning and overriding react-window's `will-change: transform` so the scroller isn't layer-promoted at all.

## Finding 1 — devices missing on the map at load (`Fix devices not appearing on map at load…`)

Two causes, both verified against a 2,500-device mock fleet:

1. **Cluster icons collision-culled.** The cluster layer had no `icon-allow-overlap`, so in dense areas the circle icon was culled: large clusters rendered as bare count text (invisible at a glance) and were **not hit-testable — clicking them did nothing**. With overlap allowed, the icon always renders and the click reliably opens the popup.
2. **Fit-to-devices suppressed by a persisted world view.** The persisted-camera restore (from #166) skipped the fit unconditionally. A session that ends before any fit persists the world view; every later load then restored that useless view and never fit to the fleet — matching the trace (map at default zoomed-out view, no fit, sidebar populated). The fit is now only skipped when the restored camera is zoom ≥ 4 (an actual place). Verified: seeded z2 world camera → fits to the fleet (z10.3); seeded z16 city camera → restores exactly, no fit.

Note on the trace's "zero /api/* requests in 12s": release-2's SocketController fetches `/api/devices` + `/api/positions` in parallel at boot (an improvement over master) — the trace simply began after boot completed. No data-flow regression exists beyond the two visibility issues above.

## Verification

Driven end-to-end against a 2,500-device mock backend (production build, headless Chrome, dark theme): fresh load fits camera to the fleet and shows cluster icons incl. the 2.4k mega-cluster; clicking it opens the (2403)-device popup instantly; wheel scrolls the virtualized list with zero long tasks; world-seeded camera fits, city-seeded camera restores. `npm run lint` 0 errors; production build clean. An adversarial multi-agent review of the diff ran before push; its two actionable findings (long-name overflow in fixed rows, scroller layer promotion) are addressed in the final commit.

## Out of scope (backend ticket)

`/api/devices` latency itself (6.8s in the original trace). Frontend dependency points: SocketController awaits the parallel devices+positions fetches before opening the WebSocket, and DeviceList issues a second concurrent `/api/devices` at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)