### PR TITLE
Fix fleet-wide marker blinking from live position updates

### DIFF
--- a/src/map/core/MapView.jsx
+++ b/src/map/core/MapView.jsx
@@ -41,6 +41,11 @@ export const restoredCamera = initialCamera;
 
 export const map = new maplibregl.Map({
   container: element,
+  // Live position updates rewrite the marker sources every batch (and every
+  // animation frame while devices move), which restarts the default 300ms
+  // symbol fade on affected markers and makes the whole fleet pulse/blink.
+  // Disable symbol fading so markers always render at full opacity.
+  fadeDuration: 0,
   ...(initialCamera && {
     center: [initialCamera.longitude, initialCamera.latitude],
     zoom: initialCamera.zoom,


### PR DESCRIPTION
## Problem

With PR #168 deployed, markers render on load — and revealed the next issue: **all device markers and cluster icons blink continuously in production**.

## Root cause

Every live update batch rewrites the marker GeoJSON sources (`setData`), and the movement-animation loop rewrites them on **every animation frame** while any device is moving. Each rewrite produces new symbol placements for anything that moved or re-clustered, and MapLibre restarts its default **300ms symbol fade** for every new placement. With a continuously reporting fleet, markers never finish fading in — the whole map pulses.

## Fix

`fadeDuration: 0` on the map — the standard setting for live-tracking maps with high-frequency source updates. Symbols always render at full opacity; placement itself was already stable.

## Verification

Reproduced with a mock backend streaming 300 moving positions per second over a real WebSocket to the production build (2,500-device fleet). Before: consecutive frames show clusters mid-transition with half-faded symbols. After: rendered-symbol counts constant across a 12s sampling run (no dips), and every symbol crisp at full opacity in consecutive frame captures. Lint and build clean.

Tradeoff: basemap label fade-in on vector styles (LocationIQ) is also disabled — labels pop in instantly instead of fading. The deployed Google raster styles are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)