### PR TITLE
Fix marker flicker and restore smooth glide for large fleets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,9 @@
   "env": {
     "browser": true
   },
+  "globals": {
+    "__GIT_COMMIT__": "readonly"
+  },
   "parserOptions": {
     "ecmaVersion": 2020
   },

--- a/.github/workflows/modern.yml
+++ b/.github/workflows/modern.yml
@@ -21,3 +21,4 @@ jobs:
         cache-dependency-path: package-lock.json
     - run: npm ci
     - run: npm run lint
+    - run: npm run test:run

--- a/src/common/util/formatter.js
+++ b/src/common/util/formatter.js
@@ -31,21 +31,39 @@ export const formatVoltage = (value, t) => `${value.toFixed(2)} ${t('sharedVoltA
 
 export const formatConsumption = (value, t) => `${value.toFixed(2)} ${t('sharedLiterPerHourAbbreviation')}`;
 
+// toLocaleString-style calls construct an implicit Intl.DateTimeFormat on
+// every invocation, which dominates the cost at fleet scale (every position
+// ingest funnels through formatTime); cache one formatter per output format.
+// Locale is the browser default (undefined), which cannot change at runtime.
+const timeFormatters = (() => {
+  const dateConfig = { year: 'numeric', month: '2-digit', day: '2-digit' };
+  const minuteConfig = { hour: '2-digit', minute: '2-digit' };
+  const secondConfig = { ...minuteConfig, second: '2-digit' };
+  return {
+    date: new Intl.DateTimeFormat(undefined, dateConfig),
+    time: new Intl.DateTimeFormat(undefined, secondConfig),
+    minutes: new Intl.DateTimeFormat(undefined, { ...dateConfig, ...minuteConfig }),
+    seconds: new Intl.DateTimeFormat(undefined, { ...dateConfig, ...secondConfig }),
+  };
+})();
+
 export const formatTime = (value, format) => {
   if (value) {
-    const d = dayjs(value).toDate();
-    const dateConfig = { year: 'numeric', month: '2-digit', day: '2-digit' };
-    const minuteConfig = { hour: '2-digit', minute: '2-digit' };
-    const secondConfig = { ...minuteConfig, second: '2-digit' };
+    // the backend emits ISO-8601 strings, which Date parses directly; keep the
+    // dayjs round-trip only as a fallback so exotic inputs format as before
+    let d = new Date(value);
+    if (Number.isNaN(d.getTime())) {
+      d = dayjs(value).toDate();
+    }
     switch (format) {
       case 'date':
-        return d.toLocaleDateString(undefined, dateConfig);
+        return timeFormatters.date.format(d);
       case 'time':
-        return d.toLocaleTimeString(undefined, secondConfig);
+        return timeFormatters.time.format(d);
       case 'minutes':
-        return d.toLocaleString(undefined, { ...dateConfig, ...minuteConfig });
+        return timeFormatters.minutes.format(d);
       default:
-        return d.toLocaleString(undefined, { ...dateConfig, ...secondConfig });
+        return timeFormatters.seconds.format(d);
     }
   }
   return '';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -16,6 +16,9 @@ import AppThemeProvider from './AppThemeProvider';
 
 preloadImages();
 
+// eslint-disable-next-line no-console
+console.log(`[build] v${import.meta.env.VITE_APP_VERSION} ${typeof __GIT_COMMIT__ !== 'undefined' ? __GIT_COMMIT__ : 'dev'}`);
+
 const projectId = 'qk7ivvfgua';
 Clarity.init(projectId);
 

--- a/src/main/useFilter.js
+++ b/src/main/useFilter.js
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import dayjs from 'dayjs';
 
 export default (keyword, filter, filterSort, filterMap, positions, setFilteredDevices, setFilteredPositions) => {
   const groups = useSelector((state) => state.groups.items);
@@ -28,13 +27,16 @@ export default (keyword, filter, filterSort, filterMap, positions, setFilteredDe
       case 'name':
         filtered.sort((device1, device2) => device1.name.localeCompare(device2.name));
         break;
-      case 'lastUpdate':
-        filtered.sort((device1, device2) => {
-          const time1 = device1.lastUpdate ? dayjs(device1.lastUpdate).valueOf() : 0;
-          const time2 = device2.lastUpdate ? dayjs(device2.lastUpdate).valueOf() : 0;
-          return time2 - time1;
+      case 'lastUpdate': {
+        // this effect re-runs on every WS flush; parse each ISO string once
+        // per run instead of 2·N·log N dayjs constructions in the comparator
+        const updateTimes = new Map();
+        filtered.forEach((device) => {
+          updateTimes.set(device.id, device.lastUpdate ? Date.parse(device.lastUpdate) || 0 : 0);
         });
+        filtered.sort((device1, device2) => updateTimes.get(device2.id) - updateTimes.get(device1.id));
         break;
+      }
       default:
         break;
     }

--- a/src/map/MapPositions.integration.test.jsx
+++ b/src/map/MapPositions.integration.test.jsx
@@ -1,0 +1,313 @@
+/**
+ * Prod-faithful integration harness for MapPositions at fleet scale.
+ *
+ * The write-cadence unit harness (MapPositions.writes.test.jsx) dispatches
+ * devicesActions.refresh ONCE and then only re-renders with new positions
+ * arrays — so state.devices.items keeps one identity for the whole run. In
+ * production every 1.5s throttle flush dispatches a devices update (lastUpdate
+ * changes on every fix), giving state.devices.items a new identity per flush.
+ * That identity flows into onClusterClick and from there into the structural
+ * effect that owns the sources, which is exactly the path that broke in prod
+ * while the unit harness stayed green.
+ *
+ * This harness reproduces the prod sequence per flush:
+ *   1. dispatch devicesActions.update(all devices, fresh lastUpdate)  (render 1)
+ *   2. deliver the new positions array as a prop                      (render 2,
+ *      like MainPage's useFilter effect)
+ * and asserts the steady-state write contract per source, per trigger label:
+ * zero fleet setData after load, updateData only on lane cadence, zero writes
+ * to an unchanged selected source, zero source teardowns.
+ */
+import React, { act } from 'react';
+import {
+  describe, it, expect, beforeAll, afterAll, vi,
+} from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+
+const { fake } = vi.hoisted(() => {
+  const handlers = new Map();
+  const sources = new Map();
+  const layers = new Map();
+  const fake = {
+    sourceOrder: [],
+    writes: [],
+    triggers: [],
+    allTriggers: [],
+    removeSourceCalls: 0,
+    featureStateCalls: [],
+    renderedDeviceIds: new Set(),
+    reset() { this.writes = []; this.triggers = []; this.featureStateCalls = []; },
+    logMapWrite(sourceId, method, count, trigger) {
+      const entry = { sourceId, method, count, trigger };
+      fake.triggers.push(entry);
+      fake.allTriggers.push(entry);
+    },
+  };
+  const fire = (event, payload) => {
+    const set = handlers.get(event);
+    if (set) [...set].forEach((h) => h(payload));
+  };
+  const contentEvent = (sourceId) => setTimeout(() => fire('sourcedata', {
+    dataType: 'source', sourceDataType: 'content', sourceId, isSourceLoaded: true,
+  }), 0);
+  const makeSource = (id, def) => ({
+    _def: def,
+    setData(data) {
+      fake.writes.push({ sourceId: id, method: 'setData', count: data.features.length });
+      contentEvent(id);
+    },
+    updateData(diff) {
+      const count = (diff.add?.length || 0) + (diff.update?.length || 0) + (diff.remove?.length || 0);
+      fake.writes.push({ sourceId: id, method: 'updateData', count, diff });
+      contentEvent(id);
+    },
+  });
+  fake.map = {
+    addSource(id, def) { sources.set(id, makeSource(id, def)); fake.sourceOrder.push(id); },
+    getSource(id) { return sources.get(id); },
+    removeSource(id) { sources.delete(id); fake.removeSourceCalls += 1; },
+    addLayer(def) { layers.set(def.id, def); },
+    getLayer(id) { return layers.get(id); },
+    removeLayer(id) { layers.delete(id); },
+    on(event, a, b) {
+      const key = b ? `${event}:${a}` : event;
+      if (!handlers.has(key)) handlers.set(key, new Set());
+      handlers.get(key).add(b || a);
+    },
+    off(event, a, b) {
+      const key = b ? `${event}:${a}` : event;
+      handlers.get(key)?.delete(b || a);
+    },
+    fire,
+    getBounds: () => ({
+      getWest: () => -10, getEast: () => 10, getSouth: () => -10, getNorth: () => 10,
+    }),
+    queryRenderedFeatures: () => [...fake.renderedDeviceIds].map((deviceId) => ({ properties: { deviceId } })),
+    setFeatureState(target, stateObj) { fake.featureStateCalls.push({ op: 'set', target, stateObj }); },
+    removeFeatureState(target, key) { fake.featureStateCalls.push({ op: 'remove', target, key }); },
+    isSourceLoaded: () => true,
+    getZoom: () => 10,
+    getCanvas: () => ({ style: {} }),
+    setPaintProperty: () => {},
+    easeTo: () => {},
+  };
+  return { fake };
+});
+
+vi.mock('./core/MapView', () => ({ map: fake.map }));
+vi.mock('./core/preloadImages', () => ({ mapIconKey: (category) => category || 'default' }));
+vi.mock('./core/mapUtil', () => ({ findFonts: () => ['Roboto Regular'] }));
+vi.mock('./core/mapWriteDebug', () => ({
+  logMapWrite: (...args) => fake.logMapWrite(...args),
+  registerMapWriteDebugSource: () => {},
+  unregisterMapWriteDebugSource: () => {},
+}));
+vi.mock('../common/util/preferences', () => ({
+  useAttributePreference: (key, defaultValue) => ({
+    mapCluster: true,
+    mapDirection: 'selected',
+    mapAnimationDuration: 2500,
+    mapEnableSmoothing: true,
+    mapAdaptiveTiming: true,
+    iconScale: 0.75,
+  }[key] ?? defaultValue),
+}));
+vi.mock('@mui/material', () => ({ useMediaQuery: () => true }));
+vi.mock('@mui/styles', () => ({ useTheme: () => ({ breakpoints: { up: () => 'md' } }) }));
+
+/* eslint-disable import/first */
+import MapPositions from './MapPositions';
+import { devicesReducer as devices, devicesActions } from '../store/devices';
+import { sessionReducer as session } from '../store/session';
+import { errorsReducer as errors } from '../store/errors';
+import { clustersReducer as clusters } from '../store/cluster';
+/* eslint-enable import/first */
+
+window.IS_REACT_ACT_ENVIRONMENT = true;
+
+const FLEET = 2900;
+const VISIBLE = 150;
+const FLUSH_MS = 1500;
+// five movers, all in the far off-viewport block: pure invisible motion,
+// which must ride the deferred reconcile lane, never per-flush writes
+const MOVER_IDS = [301, 311, 321, 331, 341];
+const MOVE_STEP = 0.0008; // > MIN_CHANGE_DEG, < teleport threshold
+
+const ALLOWED_TRIGGERS = new Set([
+  'load', 'flush-urgent', 'reconcile-15s', 'moveend', 'glide', 'selection', 'hard-reset',
+]);
+
+describe('MapPositions prod-faithful flushes (2900 devices, per-flush devices dispatch)', () => {
+  let store;
+  let root;
+  let container;
+  let posId = 1;
+  let simTime;
+  const coords = [];
+
+  const deviceList = Array.from({ length: FLEET }, (_, i) => ({
+    id: i + 1,
+    name: `Device ${i + 1}`,
+    category: 'car',
+    status: 'online',
+  }));
+
+  const makePositions = () => deviceList.map((device, i) => ({
+    id: (posId += 1),
+    deviceId: device.id,
+    longitude: coords[i].lng,
+    latitude: coords[i].lat,
+    course: 0,
+    accuracy: 0,
+    fixTime: new Date(simTime).toISOString(),
+    attributes: {},
+  }));
+
+  const onClick = () => {};
+
+  const render = (positions, selectedPosition = null) => {
+    act(() => {
+      root.render(
+        <Provider store={store}>
+          <MapPositions positions={positions} onClick={onClick} showStatus selectedPosition={selectedPosition} />
+        </Provider>,
+      );
+    });
+  };
+
+  // one production throttle cycle: devices dispatch (own commit, like the
+  // store-driven render), then the positions prop (like useFilter's effect)
+  const flush = ({ movers = false } = {}) => {
+    simTime += FLUSH_MS;
+    if (movers) {
+      MOVER_IDS.forEach((deviceId) => { coords[deviceId - 1].lng += MOVE_STEP; });
+    }
+    act(() => {
+      store.dispatch(devicesActions.update(
+        deviceList.map((d) => ({ ...d, lastUpdate: new Date(simTime).toISOString() })),
+      ));
+    });
+    render(makePositions());
+    act(() => { vi.advanceTimersByTime(FLUSH_MS); });
+  };
+
+  const label = (sourceId) => ['fleet', 'selected', 'glide'][fake.sourceOrder.indexOf(sourceId) % 3];
+  const writesFor = (name) => fake.writes.filter((w) => label(w.sourceId) === name);
+  const triggersFor = (name) => fake.triggers.filter((t) => label(t.sourceId) === name);
+
+  beforeAll(() => {
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date', 'performance', 'requestAnimationFrame', 'cancelAnimationFrame'],
+    });
+    vi.setSystemTime(new Date('2026-07-10T12:00:00Z'));
+    simTime = Date.now();
+
+    for (let i = 0; i < FLEET; i += 1) {
+      if (i < VISIBLE) {
+        coords.push({ lng: -5 + (i % 15) * 0.5, lat: -4 + Math.floor(i / 15) * 0.7 });
+      } else {
+        coords.push({ lng: 50 + (i % 50) * 0.5, lat: 20 + Math.floor(i / 50) * 0.3 });
+      }
+    }
+    for (let i = 0; i < VISIBLE; i += 1) fake.renderedDeviceIds.add(i + 1);
+
+    store = configureStore({ reducer: combineReducers({ devices, session, errors, clusters }) });
+    store.dispatch(devicesActions.refresh(deviceList));
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterAll(() => {
+    act(() => { root.unmount(); });
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('initial load: one full fleet setData labeled load, no write to the empty selected source', () => {
+    render(makePositions());
+    act(() => { vi.advanceTimersByTime(50); });
+    const fleet = writesFor('fleet');
+    expect(fleet.length).toBe(1);
+    expect(fleet[0].method).toBe('setData');
+    expect(fleet[0].count).toBe(FLEET);
+    expect(triggersFor('fleet')[0].trigger).toBe('load');
+    expect(writesFor('selected').length).toBe(0);
+    fake.reset();
+  });
+
+  it('60s of flushes with devices-identity churn: zero fleet setData, deferred-lane diffs only, zero teardowns', () => {
+    const teardownsBefore = fake.removeSourceCalls;
+    for (let n = 0; n < 40; n += 1) flush({ movers: true });
+
+    expect(fake.removeSourceCalls - teardownsBefore).toBe(0);
+
+    const fleetSetData = writesFor('fleet').filter((w) => w.method === 'setData');
+    expect(fleetSetData.length).toBe(0);
+
+    expect(writesFor('selected').length).toBe(0);
+
+    // 5 invisible movers moving every flush must coalesce into the 15s
+    // reconcile lane: ~4 writes in 60s, each diff sized by the movers
+    const fleetDiffs = writesFor('fleet');
+    expect(fleetDiffs.length).toBeGreaterThanOrEqual(2);
+    expect(fleetDiffs.length).toBeLessThanOrEqual(6);
+    fleetDiffs.forEach((w) => {
+      expect(w.method).toBe('updateData');
+      expect(w.count).toBeLessThanOrEqual(MOVER_IDS.length * 2);
+    });
+    triggersFor('fleet').forEach((t) => expect(t.trigger).toBe('reconcile-15s'));
+
+    // off-viewport movers must not surface in the glide source
+    expect(writesFor('glide').length).toBe(0);
+    fake.reset();
+  });
+
+  it('a status change is urgent: written within its flush as a device-sized diff', () => {
+    deviceList[500] = { ...deviceList[500], status: 'offline' };
+    flush();
+    const fleetDiffs = writesFor('fleet');
+    expect(fleetDiffs.length).toBe(1);
+    expect(fleetDiffs[0].method).toBe('updateData');
+    // the status device plus at most the piggybacked deferred backlog
+    expect(fleetDiffs[0].count).toBeLessThanOrEqual(1 + MOVER_IDS.length);
+    expect(triggersFor('fleet')[0].trigger).toBe('flush-urgent');
+    fake.reset();
+  });
+
+  it('moveend flushes the deferred backlog with the moveend label', () => {
+    flush({ movers: true });
+    flush({ movers: true });
+    expect(writesFor('fleet').length).toBe(0); // 3s < 15s: still deferred
+    act(() => { fake.map.fire('moveend'); });
+    const fleetDiffs = writesFor('fleet');
+    expect(fleetDiffs.length).toBe(1);
+    expect(fleetDiffs[0].method).toBe('updateData');
+    expect(triggersFor('fleet')[0].trigger).toBe('moveend');
+    fake.reset();
+  });
+
+  it('selection swaps one device between sources, labeled selection', () => {
+    act(() => { store.dispatch(devicesActions.selectId(MOVER_IDS[0])); });
+    const selectedWrites = writesFor('selected');
+    expect(selectedWrites.length).toBe(1);
+    expect(selectedWrites[0].method).toBe('updateData');
+    expect(selectedWrites[0].count).toBe(1);
+    expect(triggersFor('selected')[0].trigger).toBe('selection');
+    const fleetWrites = writesFor('fleet');
+    expect(fleetWrites.length).toBe(1);
+    expect(fleetWrites[0].method).toBe('updateData');
+    expect(triggersFor('fleet')[0].trigger).toBe('selection');
+    act(() => { store.dispatch(devicesActions.selectId(null)); });
+    fake.reset();
+  });
+
+  it('no write anywhere in the run carried the legacy flush label; all labels are in the taxonomy', () => {
+    const flushLabeled = fake.allTriggers.filter((t) => t.trigger === 'flush');
+    expect(flushLabeled.length).toBe(0);
+    fake.allTriggers.forEach((t) => expect(ALLOWED_TRIGGERS.has(t.trigger)).toBe(true));
+  });
+});

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -20,12 +20,20 @@ const TELEPORT_THRESHOLD_SQ = 0.0045 * 0.0045;
 const STALE_GAP_MS = 10000;
 const MIN_CHANGE_DEG = 0.000005;
 
-// Every setData re-tiles the source in the worker and restarts symbol
-// placement, which reads as fleet-wide marker flicker when it happens on
-// every animation frame. Above this fleet size, animation writes are
-// coalesced to one per interval; the final landing write always goes through.
+// Every content write to a GeoJSON source — setData AND updateData alike in
+// maplibre-gl 4.7.1 — re-tiles the whole source in the worker and restarts
+// symbol placement (SourceCache.reload reloads every tile on any 'content'
+// event), which reads as fleet-wide marker flicker. The only real lever is
+// writing the fleet source less. Above this fleet size, writes go through a
+// diff mirror: a write is skipped entirely when nothing render-relevant
+// changed, visible changes (adds/removes/status/jumps) flush within the
+// animation interval, and invisible geometry churn (clustered, off-viewport,
+// hidden gliding twins) batches into one reconcile write per deferred
+// interval, on moveend, or when motion stops. updateData carries the diffs so
+// the remaining writes serialize only changed features.
 const PER_FRAME_WRITE_MAX_FLEET = 300;
 const ANIMATION_WRITE_INTERVAL_MS = 1000;
+const DEFERRED_RECONCILE_INTERVAL_MS = 15000;
 
 // Smooth glide for large fleets: devices with a fresh position glide through a
 // small dedicated GeoJSON source written at ~15fps (cost is O(gliding devices),
@@ -37,6 +45,23 @@ const GLIDE_WRITE_INTERVAL_MS = 66;
 const GLIDE_VIEWPORT_PAD = 0.2;
 
 const hiddenWhenAnimating = (visible) => ['case', ['boolean', ['feature-state', 'animating'], false], 0, visible];
+
+// Render-relevant equality for the diff mirror. properties.id (per-fix
+// position id) and properties.fixTime are deliberately excluded: they refresh
+// on every fix even for a parked device, and comparing them would turn every
+// flush into a full-fleet rewrite — the exact symptom this diff exists to
+// remove. Neither is rendered on the live map (labels use titleField, default
+// 'name'); they ride along whenever a device is written for a real change.
+const propsRenderEqual = (a, b, titleKey) => a.properties.name === b.properties.name
+  && a.properties.category === b.properties.category
+  && a.properties.color === b.properties.color
+  && a.properties.direction === b.properties.direction
+  && a.properties[titleKey] === b.properties[titleKey];
+
+const renderEquals = (a, b, titleKey) => propsRenderEqual(a, b, titleKey)
+  && a.geometry.coordinates[0] === b.geometry.coordinates[0]
+  && a.geometry.coordinates[1] === b.geometry.coordinates[1]
+  && a.properties.rotation === b.properties.rotation;
 
 const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleField }) => {
   const id = useId();
@@ -72,6 +97,11 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   const glidePhaseRef = useRef({});
   const glideLastWriteRef = useRef(0);
   const writeGlideSourceRef = useRef(() => {});
+  // per-source Map<deviceId, feature> mirroring what the map sources hold;
+  // null forces the next large-fleet write to be a full setData
+  const lastWrittenRef = useRef(null);
+  const lastDeferredWriteRef = useRef(0);
+  const updateMapDataRef = useRef(() => {});
 
   useEffect(() => {
     devicesRef.current = devices;
@@ -190,39 +220,159 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const currentSelectedId = selectedDeviceIdRef.current;
     const currentSelectedPos = selectedPositionRef.current;
 
-    [id, selected].forEach((source) => {
-      const sourceObj = map.getSource(source);
-      if (!sourceObj) return;
+    if (vals.length <= PER_FRAME_WRITE_MAX_FLEET) {
+      // small fleets and replay keep the original per-frame full-write path
+      lastWrittenRef.current = null;
+      [id, selected].forEach((source) => {
+        const sourceObj = map.getSource(source);
+        if (!sourceObj) return;
 
-      const features = vals
-        .filter((ds) => Object.prototype.hasOwnProperty.call(currentDevices, ds.properties.deviceId))
-        .filter((ds) => {
-          const isSel = ds.properties.deviceId === currentSelectedId;
-          return source === id ? !isSel : isSel;
-        })
-        .map((ds) => ({
-          type: 'Feature',
-          geometry: { type: 'Point', coordinates: [ds.current.longitude, ds.current.latitude] },
-          properties: {
-            ...createFeature(currentDevices, ds.properties, currentSelectedPos?.id),
-            rotation: ds.current.rotation,
-          },
-        }));
+        const features = vals
+          .filter((ds) => Object.prototype.hasOwnProperty.call(currentDevices, ds.properties.deviceId))
+          .filter((ds) => {
+            const isSel = ds.properties.deviceId === currentSelectedId;
+            return source === id ? !isSel : isSel;
+          })
+          .map((ds) => ({
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [ds.current.longitude, ds.current.latitude] },
+            properties: {
+              ...createFeature(currentDevices, ds.properties, currentSelectedPos?.id),
+              rotation: ds.current.rotation,
+            },
+          }));
 
-      sourceObj.setData({ type: 'FeatureCollection', features });
-      logMapWrite(source, 'setData', features.length, trigger);
+        sourceObj.setData({ type: 'FeatureCollection', features });
+        logMapWrite(source, 'setData', features.length, trigger);
+      });
+
+      Object.keys(glidePhaseRef.current).forEach((key) => {
+        if (glidePhaseRef.current[key] === 'landed') {
+          glidePhaseRef.current[key] = 'reconciling';
+        }
+      });
+
+      lastMapWriteRef.current = Date.now();
+      return;
+    }
+
+    // Large-fleet incremental path. Stamp the attempt (not just the write) so
+    // the animation loop diffs at most once per ANIMATION_WRITE_INTERVAL_MS.
+    const now = Date.now();
+    lastMapWriteRef.current = now;
+    const titleKey = titleField || 'name';
+    const phases = glidePhaseRef.current;
+    const mirror = lastWrittenRef.current;
+    const next = { [id]: new Map(), [selected]: new Map() };
+    const urgent = { [id]: [], [selected]: [] };
+    const deferred = { [id]: [], [selected]: [] };
+    const removes = { [id]: [], [selected]: [] };
+    const jumpedDs = [];
+    let urgentCount = 0;
+    let deferredCount = 0;
+
+    vals.forEach((ds) => {
+      const position = ds.properties;
+      const { deviceId } = position;
+      if (!Object.prototype.hasOwnProperty.call(currentDevices, deviceId)) return;
+      const sourceKey = deviceId === currentSelectedId ? selected : id;
+      const feature = {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [ds.current.longitude, ds.current.latitude] },
+        properties: {
+          ...createFeature(currentDevices, position, currentSelectedPos?.id),
+          rotation: ds.current.rotation,
+        },
+      };
+      const prev = mirror?.[sourceKey]?.get(deviceId);
+      if (prev && renderEquals(prev, feature, titleKey)) {
+        next[sourceKey].set(deviceId, prev);
+        return;
+      }
+      const phase = phases[deviceId];
+      if (prev && (phase === 'entering' || phase === 'active')) {
+        // twin hidden, copy rendering live from the glide source: writing
+        // intermediate coordinates would be invisible churn
+        next[sourceKey].set(deviceId, prev);
+        return;
+      }
+      if (prev && sourceKey === id && !ds.jumped && propsRenderEqual(prev, feature, titleKey)) {
+        // pure motion of something not individually visible (clustered,
+        // off-viewport, or a hidden landed twin): slow reconcile lane
+        deferred[sourceKey].push(feature);
+        next[sourceKey].set(deviceId, prev);
+        deferredCount += 1;
+        return;
+      }
+      urgent[sourceKey].push(feature);
+      next[sourceKey].set(deviceId, feature);
+      urgentCount += 1;
+      if (ds.jumped) jumpedDs.push(ds);
     });
+
+    if (mirror) {
+      [id, selected].forEach((sourceKey) => {
+        mirror[sourceKey].forEach((feature, deviceId) => {
+          if (!next[sourceKey].has(deviceId)) {
+            removes[sourceKey].push(deviceId);
+            urgentCount += 1;
+          }
+        });
+      });
+    }
+
+    // 'landing' (fleet-wide quiescence) deliberately does NOT force the flush:
+    // the throttle middleware synchronizes flushes, so glides finish together
+    // between flushes and quiescence recurs every cycle — forcing here would
+    // reinstate a per-cycle full re-tile. Parked glide copies render the exact
+    // final coordinates until the interval (or a pan) reconciles them.
+    const deferredDue = deferredCount > 0 && (
+      trigger === 'moveend'
+      || now - lastDeferredWriteRef.current >= DEFERRED_RECONCILE_INTERVAL_MS
+    );
+    if (mirror && urgentCount === 0 && !deferredDue) return;
+
+    // any write flushes the deferred backlog too: the re-tile happens anyway
+    [id, selected].forEach((sourceKey) => {
+      deferred[sourceKey].forEach((feature) => next[sourceKey].set(feature.properties.deviceId, feature));
+    });
+    lastDeferredWriteRef.current = now;
+
+    [id, selected].forEach((sourceKey) => {
+      const sourceObj = map.getSource(sourceKey);
+      if (!sourceObj) return;
+      if (!mirror) {
+        const features = [...next[sourceKey].values()];
+        sourceObj.setData({ type: 'FeatureCollection', features });
+        logMapWrite(sourceKey, 'setData', features.length, trigger);
+        return;
+      }
+      const add = urgent[sourceKey].concat(deferred[sourceKey]);
+      const remove = removes[sourceKey];
+      if (!add.length && !remove.length) return; // untouched source: no re-tile
+      // 'add' with an existing promoteId (deviceId) replaces that feature
+      sourceObj.updateData({ add, remove });
+      logMapWrite(sourceKey, 'updateData', add.length + remove.length, trigger);
+    });
+
+    lastWrittenRef.current = next;
+    jumpedDs.forEach((ds) => { ds.jumped = false; });
 
     // landed gliders are part of this write; once it is loaded their twin
     // shows the exact final position and the copy can be swapped out
-    Object.keys(glidePhaseRef.current).forEach((key) => {
-      if (glidePhaseRef.current[key] === 'landed') {
-        glidePhaseRef.current[key] = 'reconciling';
+    Object.keys(phases).forEach((key) => {
+      if (phases[key] === 'landed') {
+        phases[key] = 'reconciling';
       }
     });
+  }, [id, selected, createFeature, titleField]);
 
-    lastMapWriteRef.current = Date.now();
-  }, [id, selected, createFeature]);
+  useEffect(() => {
+    updateMapDataRef.current = updateMapData;
+    // feature properties are derived through createFeature/titleField; when
+    // those change the mirror no longer matches the sources, so rebuild fully
+    lastWrittenRef.current = null;
+  }, [updateMapData]);
 
   const animate = useCallback(() => {
     const now = Date.now();
@@ -321,7 +471,9 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
 
       const isJump = (longitude - cLng) ** 2 + (latitude - cLat) ** 2 > TELEPORT_THRESHOLD_SQ;
       if (isJump || !enableSmoothing) {
-        state[deviceId] = { current: { longitude, latitude, rotation }, target: null, startTime: now, properties: position };
+        // jumped: a discontinuous (or unsmoothed) move may be visible, so the
+        // incremental writer treats it as urgent instead of deferring it
+        state[deviceId] = { current: { longitude, latitude, rotation }, target: null, startTime: now, properties: position, jumped: true };
         lastUpdateTimeRef.current[deviceId] = now;
         const phase = glidePhaseRef.current[deviceId];
         if (phase === 'entering') {
@@ -453,6 +605,8 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     registerMapWriteDebugSource(id, 'fleet');
     registerMapWriteDebugSource(selected, 'selected');
     registerMapWriteDebugSource(animating, 'glide');
+    // sources were just (re)created empty: the diff mirror is void
+    lastWrittenRef.current = null;
 
     [id, selected].forEach((source) => {
       const isSelectedLayer = source === selected;
@@ -614,6 +768,9 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         changed = true;
       });
       if (changed) writeGlideSourceRef.current();
+      // the pan/zoom may have revealed devices whose deferred coordinates are
+      // stale; flush the backlog while the repaint masks the re-tile
+      updateMapDataRef.current(undefined, 'moveend');
     };
     map.on('moveend', onGlideMoveEnd);
 
@@ -639,6 +796,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       if (map.getSource(animating)) map.removeSource(animating);
       glidePhaseRef.current = {};
       glideLastWriteRef.current = 0;
+      lastWrittenRef.current = null;
 
       [id, selected].forEach((source) => {
         map.off('mouseenter', source, onMouseEnter);

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -19,6 +19,13 @@ const TELEPORT_THRESHOLD_SQ = 0.0045 * 0.0045;
 const STALE_GAP_MS = 10000;
 const MIN_CHANGE_DEG = 0.000005;
 
+// Every setData re-tiles the source in the worker and restarts symbol
+// placement, which reads as fleet-wide marker flicker when it happens on
+// every animation frame. Above this fleet size, animation writes are
+// coalesced to one per interval; the final landing write always goes through.
+const PER_FRAME_WRITE_MAX_FLEET = 300;
+const ANIMATION_WRITE_INTERVAL_MS = 1000;
+
 const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleField }) => {
   const id = useId();
   const clusters = `${id}-clusters`;
@@ -46,6 +53,8 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   const selectedPositionRef = useRef(selectedPosition);
   const lastUpdateTimeRef = useRef({});
   const lastCoordRef = useRef({});
+  const lastMapWriteRef = useRef(0);
+  const fixTimeCacheRef = useRef({});
 
   useEffect(() => {
     devicesRef.current = devices;
@@ -66,11 +75,20 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       case 'all': showDirection = position.course > 0; break;
       default: showDirection = selectedPositionId === position.id && position.course > 0; break;
     }
+    // formatTime parses the ISO string through dayjs and Intl on every call;
+    // at fleet scale this dominates the main thread, so only re-format when
+    // the device actually has a new fix time.
+    const cache = fixTimeCacheRef.current;
+    let fixTimeEntry = cache[position.deviceId];
+    if (!fixTimeEntry || fixTimeEntry.raw !== position.fixTime) {
+      fixTimeEntry = { raw: position.fixTime, formatted: formatTime(position.fixTime, 'seconds') };
+      cache[position.deviceId] = fixTimeEntry;
+    }
     return {
       id: position.id,
       deviceId: position.deviceId,
       name: device.name,
-      fixTime: formatTime(position.fixTime, 'seconds'),
+      fixTime: fixTimeEntry.formatted,
       category: mapIconKey(device.category),
       color: showStatus ? position.attributes.color || getStatusColor(device.status) : 'neutral',
       rotation: position.course,
@@ -114,6 +132,8 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
 
       sourceObj.setData({ type: 'FeatureCollection', features });
     });
+
+    lastMapWriteRef.current = Date.now();
   }, [id, selected, createFeature]);
 
   const animate = useCallback(() => {
@@ -143,7 +163,13 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       needsUpdate = true;
     });
 
-    if (needsUpdate) updateMapData(stateVals);
+    if (needsUpdate) {
+      const stillAnimating = stateVals.some((ds) => ds.target);
+      const writeInterval = stateVals.length > PER_FRAME_WRITE_MAX_FLEET ? ANIMATION_WRITE_INTERVAL_MS : 0;
+      if (!stillAnimating || now - lastMapWriteRef.current >= writeInterval) {
+        updateMapData(stateVals);
+      }
+    }
 
     if (hasTargets) {
       animationFrameRef.current = requestAnimationFrame(animate);
@@ -217,6 +243,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         delete state[deviceId];
         delete lastUpdateTimeRef.current[deviceId];
         delete lastCoordRef.current[deviceId];
+        delete fixTimeCacheRef.current[deviceId];
       }
     });
 

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -12,6 +12,7 @@ import { useCatchCallback } from '../reactHelper';
 import { findFonts } from './core/mapUtil';
 import { lerp, easeInOutCubic, interpolateRotation } from '../common/util/useAnimation';
 import { clustersActions } from '../store/cluster';
+import { logMapWrite, registerMapWriteDebugSource, unregisterMapWriteDebugSource } from './core/mapWriteDebug';
 
 const CLUSTER_POPUP_MIN_ZOOM = 9;
 
@@ -80,7 +81,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
 
   useEffect(() => {
     selectedDeviceIdRef.current = selectedDeviceId;
-    if (map.getSource(id)) updateMapData(); // eslint-disable-line no-use-before-define
+    if (map.getSource(id)) updateMapData(undefined, 'selection'); // eslint-disable-line no-use-before-define
   }, [selectedDeviceId]);
 
   const createFeature = useCallback((devs, position, selectedPositionId) => {
@@ -175,6 +176,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       }));
 
     sourceObj.setData({ type: 'FeatureCollection', features });
+    logMapWrite(animating, 'setData', features.length, 'glide');
     glideLastWriteRef.current = Date.now();
   }, [animating, createFeature]);
 
@@ -182,7 +184,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     writeGlideSourceRef.current = writeGlideSource;
   }, [writeGlideSource]);
 
-  const updateMapData = useCallback((stateVals) => {
+  const updateMapData = useCallback((stateVals, trigger = 'flush') => {
     const vals = stateVals ?? Object.values(animationStateRef.current);
     const currentDevices = devicesRef.current;
     const currentSelectedId = selectedDeviceIdRef.current;
@@ -208,6 +210,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         }));
 
       sourceObj.setData({ type: 'FeatureCollection', features });
+      logMapWrite(source, 'setData', features.length, trigger);
     });
 
     // landed gliders are part of this write; once it is loaded their twin
@@ -260,7 +263,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       const stillAnimating = stateVals.some((ds) => ds.target);
       const writeInterval = stateVals.length > PER_FRAME_WRITE_MAX_FLEET ? ANIMATION_WRITE_INTERVAL_MS : 0;
       if (!stillAnimating || now - lastMapWriteRef.current >= writeInterval) {
-        updateMapData(stateVals);
+        updateMapData(stateVals, stillAnimating ? 'animation' : 'landing');
       }
       if (Object.keys(glidePhaseRef.current).length
         && (!stillAnimating || now - glideLastWriteRef.current >= GLIDE_WRITE_INTERVAL_MS)) {
@@ -447,6 +450,9 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       type: 'geojson',
       data: { type: 'FeatureCollection', features: [] },
     });
+    registerMapWriteDebugSource(id, 'fleet');
+    registerMapWriteDebugSource(selected, 'selected');
+    registerMapWriteDebugSource(animating, 'glide');
 
     [id, selected].forEach((source) => {
       const isSelectedLayer = source === selected;
@@ -614,6 +620,9 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     return () => {
       if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
 
+      unregisterMapWriteDebugSource(id);
+      unregisterMapWriteDebugSource(selected);
+      unregisterMapWriteDebugSource(animating);
       map.off('sourcedata', onGlideSourceData);
       map.off('moveend', onGlideMoveEnd);
       map.off('mouseenter', clusters, onMouseEnter);

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -58,6 +58,14 @@ const propsRenderEqual = (a, b, titleKey) => a.properties.name === b.properties.
   && a.properties.direction === b.properties.direction
   && a.properties[titleKey] === b.properties[titleKey];
 
+// Field-verification trigger taxonomy: writes caused by a selection change or
+// a pan keep that label; anything else is labeled by the lane it took —
+// urgent diffs as 'flush-urgent', pure deferred backlog as 'reconcile-15s'.
+const laneTrigger = (reason, urgentHere) => {
+  if (reason === 'selection' || reason === 'moveend') return reason;
+  return urgentHere ? 'flush-urgent' : 'reconcile-15s';
+};
+
 const renderEquals = (a, b, titleKey) => propsRenderEqual(a, b, titleKey)
   && a.geometry.coordinates[0] === b.geometry.coordinates[0]
   && a.geometry.coordinates[1] === b.geometry.coordinates[1]
@@ -98,10 +106,19 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   const glideLastWriteRef = useRef(0);
   const writeGlideSourceRef = useRef(() => {});
   // per-source Map<deviceId, feature> mirroring what the map sources hold;
-  // null forces the next large-fleet write to be a full setData
+  // null means the source content is unknown (small-fleet path wrote it)
   const lastWrittenRef = useRef(null);
+  // truthy = the mirror's features can't be trusted for diffing and the next
+  // large-fleet write must rewrite fully; the value is the trigger label
+  // ('load' after source creation, 'hard-reset' after derived-prop changes)
+  const fullRewriteReasonRef = useRef('load');
   const lastDeferredWriteRef = useRef(0);
   const updateMapDataRef = useRef(() => {});
+  const onClickRef = useRef(onClick);
+
+  useEffect(() => {
+    onClickRef.current = onClick;
+  }, [onClick]);
 
   useEffect(() => {
     devicesRef.current = devices;
@@ -214,15 +231,24 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     writeGlideSourceRef.current = writeGlideSource;
   }, [writeGlideSource]);
 
-  const updateMapData = useCallback((stateVals, trigger = 'flush') => {
+  // 'reason' is the call site's cause ('data' for a positions/devices flush,
+  // 'animation'/'landing' from the loop, 'selection', 'moveend'); the logged
+  // trigger is derived from the lane a write actually takes: load,
+  // flush-urgent, reconcile-15s, moveend, selection, hard-reset.
+  const updateMapData = useCallback((stateVals, reason = 'data') => {
     const vals = stateVals ?? Object.values(animationStateRef.current);
     const currentDevices = devicesRef.current;
     const currentSelectedId = selectedDeviceIdRef.current;
     const currentSelectedPos = selectedPositionRef.current;
 
     if (vals.length <= PER_FRAME_WRITE_MAX_FLEET) {
-      // small fleets and replay keep the original per-frame full-write path
+      // small fleets and replay keep the original per-frame full-write path;
+      // it writes outside the mirror, so a later large-fleet write must
+      // rebuild without trusting it
+      const smallTrigger = lastMapWriteRef.current === 0 && reason === 'data'
+        ? 'load' : laneTrigger(reason, true);
       lastWrittenRef.current = null;
+      fullRewriteReasonRef.current = 'hard-reset';
       [id, selected].forEach((source) => {
         const sourceObj = map.getSource(source);
         if (!sourceObj) return;
@@ -243,7 +269,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
           }));
 
         sourceObj.setData({ type: 'FeatureCollection', features });
-        logMapWrite(source, 'setData', features.length, trigger);
+        logMapWrite(source, 'setData', features.length, smallTrigger);
       });
 
       Object.keys(glidePhaseRef.current).forEach((key) => {
@@ -263,6 +289,11 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const titleKey = titleField || 'name';
     const phases = glidePhaseRef.current;
     const mirror = lastWrittenRef.current;
+    const fullReason = fullRewriteReasonRef.current;
+    // diff only when the mirror exists AND still matches the sources; after a
+    // hard reset its features are stale, but its per-source sizes still say
+    // which sources hold content (used to skip empty->empty rewrites below)
+    const diffable = !!mirror && !fullReason;
     const next = { [id]: new Map(), [selected]: new Map() };
     const urgent = { [id]: [], [selected]: [] };
     const deferred = { [id]: [], [selected]: [] };
@@ -284,7 +315,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
           rotation: ds.current.rotation,
         },
       };
-      const prev = mirror?.[sourceKey]?.get(deviceId);
+      const prev = diffable ? mirror[sourceKey].get(deviceId) : undefined;
       if (prev && renderEquals(prev, feature, titleKey)) {
         next[sourceKey].set(deviceId, prev);
         return;
@@ -310,7 +341,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       if (ds.jumped) jumpedDs.push(ds);
     });
 
-    if (mirror) {
+    if (diffable) {
       [id, selected].forEach((sourceKey) => {
         mirror[sourceKey].forEach((feature, deviceId) => {
           if (!next[sourceKey].has(deviceId)) {
@@ -327,10 +358,10 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     // reinstate a per-cycle full re-tile. Parked glide copies render the exact
     // final coordinates until the interval (or a pan) reconciles them.
     const deferredDue = deferredCount > 0 && (
-      trigger === 'moveend'
+      reason === 'moveend'
       || now - lastDeferredWriteRef.current >= DEFERRED_RECONCILE_INTERVAL_MS
     );
-    if (mirror && urgentCount === 0 && !deferredDue) return;
+    if (diffable && urgentCount === 0 && !deferredDue) return;
 
     // any write flushes the deferred backlog too: the re-tile happens anyway
     [id, selected].forEach((sourceKey) => {
@@ -341,10 +372,14 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     [id, selected].forEach((sourceKey) => {
       const sourceObj = map.getSource(sourceKey);
       if (!sourceObj) return;
-      if (!mirror) {
+      if (!diffable) {
         const features = [...next[sourceKey].values()];
+        // rewriting a known-empty source with zero features would re-tile for
+        // nothing (this was the recurring 0-feature write on the selected
+        // source); a null mirror means content is unknown, so still write
+        if (!features.length && mirror && mirror[sourceKey].size === 0) return;
         sourceObj.setData({ type: 'FeatureCollection', features });
-        logMapWrite(sourceKey, 'setData', features.length, trigger);
+        logMapWrite(sourceKey, 'setData', features.length, fullReason || 'hard-reset');
         return;
       }
       const add = urgent[sourceKey].concat(deferred[sourceKey]);
@@ -352,10 +387,12 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       if (!add.length && !remove.length) return; // untouched source: no re-tile
       // 'add' with an existing promoteId (deviceId) replaces that feature
       sourceObj.updateData({ add, remove });
-      logMapWrite(sourceKey, 'updateData', add.length + remove.length, trigger);
+      const urgentHere = urgent[sourceKey].length + remove.length;
+      logMapWrite(sourceKey, 'updateData', add.length + remove.length, laneTrigger(reason, urgentHere));
     });
 
     lastWrittenRef.current = next;
+    fullRewriteReasonRef.current = null;
     jumpedDs.forEach((ds) => { ds.jumped = false; });
 
     // landed gliders are part of this write; once it is loaded their twin
@@ -370,8 +407,11 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   useEffect(() => {
     updateMapDataRef.current = updateMapData;
     // feature properties are derived through createFeature/titleField; when
-    // those change the mirror no longer matches the sources, so rebuild fully
-    lastWrittenRef.current = null;
+    // those change the mirror's features no longer match the sources, so the
+    // next write rebuilds fully (the mirror maps are kept: their sizes still
+    // say which sources hold content). On mount this runs before the source
+    // effect, which overwrites the reason with 'load'.
+    fullRewriteReasonRef.current = 'hard-reset';
   }, [updateMapData]);
 
   const animate = useCallback(() => {
@@ -542,15 +582,21 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   const onMouseEnter = () => { map.getCanvas().style.cursor = 'pointer'; };
   const onMouseLeave = () => { map.getCanvas().style.cursor = ''; };
 
+  // These handlers are dependencies of the structural effect that owns the
+  // sources and layers. They read everything per-render state through refs so
+  // their identities never change: if any of them picked up a new identity on
+  // a WS flush (the devices selector changes every flush), the structural
+  // effect would tear down and recreate the sources each cycle, destroying
+  // the diff mirror and re-tiling the fleet — the prod blink.
   const onMapClick = useCallback((event) => {
-    if (!event.defaultPrevented && onClick) onClick(event.lngLat.lat, event.lngLat.lng);
-  }, [onClick]);
+    if (!event.defaultPrevented && onClickRef.current) onClickRef.current(event.lngLat.lat, event.lngLat.lng);
+  }, []);
 
   const onMarkerClick = useCallback((event) => {
     event.preventDefault();
     const { id: fId, deviceId } = event.features[0].properties;
-    if (onClick) onClick(fId, deviceId);
-  }, [onClick]);
+    if (onClickRef.current) onClickRef.current(fId, deviceId);
+  }, []);
 
   const onClusterClick = useCatchCallback(async (event) => {
     event.preventDefault();
@@ -574,14 +620,14 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const leaves = await source.getClusterLeaves(clusterId, Infinity, 0);
 
     const clusterDevices = leaves
-      .map((feature) => devices[feature.properties.deviceId])
+      .map((feature) => devicesRef.current[feature.properties.deviceId])
       .filter(Boolean);
 
     dispatch(clustersActions.showClusterPopup({
       devices: clusterDevices,
       coordinates: clusterCoords,
     }));
-  }, [clusters, devices]);
+  }, [clusters, dispatch]);
 
   useEffect(() => {
     map.addSource(id, {
@@ -605,8 +651,10 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     registerMapWriteDebugSource(id, 'fleet');
     registerMapWriteDebugSource(selected, 'selected');
     registerMapWriteDebugSource(animating, 'glide');
-    // sources were just (re)created empty: the diff mirror is void
-    lastWrittenRef.current = null;
+    // sources were just (re)created empty: start from a known-empty mirror so
+    // the first write is a 'load' setData and empty sources are never written
+    lastWrittenRef.current = { [id]: new Map(), [selected]: new Map() };
+    fullRewriteReasonRef.current = 'load';
 
     [id, selected].forEach((source) => {
       const isSelectedLayer = source === selected;

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -26,10 +26,22 @@ const MIN_CHANGE_DEG = 0.000005;
 const PER_FRAME_WRITE_MAX_FLEET = 300;
 const ANIMATION_WRITE_INTERVAL_MS = 1000;
 
+// Smooth glide for large fleets: devices with a fresh position glide through a
+// small dedicated GeoJSON source written at ~15fps (cost is O(gliding devices),
+// not fleet size), while their static twin in the full source is hidden via
+// feature-state — a paint-only change with no worker round-trip. Only devices
+// rendered individually inside the padded viewport participate; everything
+// else keeps stepping at the reconcile cadence.
+const GLIDE_WRITE_INTERVAL_MS = 66;
+const GLIDE_VIEWPORT_PAD = 0.2;
+
+const hiddenWhenAnimating = (visible) => ['case', ['boolean', ['feature-state', 'animating'], false], 0, visible];
+
 const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleField }) => {
   const id = useId();
   const clusters = `${id}-clusters`;
   const selected = `${id}-selected`;
+  const animating = `${id}-animating`;
 
   const dispatch = useDispatch();
   const theme = useTheme();
@@ -55,6 +67,10 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   const lastCoordRef = useRef({});
   const lastMapWriteRef = useRef(0);
   const fixTimeCacheRef = useRef({});
+  // deviceId -> 'entering' | 'active' | 'landed' | 'reconciling'
+  const glidePhaseRef = useRef({});
+  const glideLastWriteRef = useRef(0);
+  const writeGlideSourceRef = useRef(() => {});
 
   useEffect(() => {
     devicesRef.current = devices;
@@ -105,6 +121,67 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     return Math.max(500, Math.min(gap * 0.8, 5000));
   }, [baseAnimationDuration, useAdaptiveTiming]);
 
+  const setTwinHidden = useCallback((deviceId, hidden) => {
+    [id, selected].forEach((source) => {
+      if (!map.getSource(source)) return;
+      if (hidden) {
+        map.setFeatureState({ source, id: deviceId }, { animating: true });
+      } else {
+        map.removeFeatureState({ source, id: deviceId }, 'animating');
+      }
+    });
+  }, [id, selected]);
+
+  const glideEligibleIds = useCallback((candidateIds) => {
+    const bounds = map.getBounds();
+    const padLng = (bounds.getEast() - bounds.getWest()) * GLIDE_VIEWPORT_PAD;
+    const padLat = (bounds.getNorth() - bounds.getSouth()) * GLIDE_VIEWPORT_PAD;
+    const within = (coord) => coord
+      && coord.longitude >= bounds.getWest() - padLng && coord.longitude <= bounds.getEast() + padLng
+      && coord.latitude >= bounds.getSouth() - padLat && coord.latitude <= bounds.getNorth() + padLat;
+    const layersToQuery = [id, selected].filter((layer) => map.getLayer(layer));
+    const rendered = layersToQuery.length
+      ? new Set(map.queryRenderedFeatures({ layers: layersToQuery }).map((f) => f.properties.deviceId))
+      : new Set();
+    return candidateIds.filter((deviceId) => {
+      const ds = animationStateRef.current[deviceId];
+      if (!ds || !(within(ds.current) || within(ds.target))) return false;
+      // devices absorbed into a cluster are not individually visible; let them
+      // snap at the reconcile cadence instead of surfacing a transient marker.
+      // Already-gliding devices stay eligible: their twin is transparent but
+      // still placed, and feature-state keeps it out of the rendered check.
+      return glidePhaseRef.current[deviceId] ? true : rendered.has(deviceId);
+    });
+  }, [id, selected]);
+
+  const writeGlideSource = useCallback(() => {
+    const sourceObj = map.getSource(animating);
+    if (!sourceObj) return;
+    const currentDevices = devicesRef.current;
+    const currentSelectedId = selectedDeviceIdRef.current;
+    const currentSelectedPos = selectedPositionRef.current;
+
+    const features = Object.keys(glidePhaseRef.current)
+      .map((key) => animationStateRef.current[key])
+      .filter((ds) => ds && Object.prototype.hasOwnProperty.call(currentDevices, ds.properties.deviceId))
+      .map((ds) => ({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [ds.current.longitude, ds.current.latitude] },
+        properties: {
+          ...createFeature(currentDevices, ds.properties, currentSelectedPos?.id),
+          rotation: ds.current.rotation,
+          selected: ds.properties.deviceId === currentSelectedId,
+        },
+      }));
+
+    sourceObj.setData({ type: 'FeatureCollection', features });
+    glideLastWriteRef.current = Date.now();
+  }, [animating, createFeature]);
+
+  useEffect(() => {
+    writeGlideSourceRef.current = writeGlideSource;
+  }, [writeGlideSource]);
+
   const updateMapData = useCallback((stateVals) => {
     const vals = stateVals ?? Object.values(animationStateRef.current);
     const currentDevices = devicesRef.current;
@@ -133,6 +210,14 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       sourceObj.setData({ type: 'FeatureCollection', features });
     });
 
+    // landed gliders are part of this write; once it is loaded their twin
+    // shows the exact final position and the copy can be swapped out
+    Object.keys(glidePhaseRef.current).forEach((key) => {
+      if (glidePhaseRef.current[key] === 'landed') {
+        glidePhaseRef.current[key] = 'reconciling';
+      }
+    });
+
     lastMapWriteRef.current = Date.now();
   }, [id, selected, createFeature]);
 
@@ -159,6 +244,14 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         ds.current = { ...ds.target };
         ds.target = null;
         ds.start = null;
+        const { deviceId } = ds.properties;
+        const phase = glidePhaseRef.current[deviceId];
+        if (phase === 'entering') {
+          // the twin was never hidden, so just drop out of the glide source
+          delete glidePhaseRef.current[deviceId];
+        } else if (phase === 'active') {
+          glidePhaseRef.current[deviceId] = 'landed';
+        }
       }
       needsUpdate = true;
     });
@@ -169,6 +262,12 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       if (!stillAnimating || now - lastMapWriteRef.current >= writeInterval) {
         updateMapData(stateVals);
       }
+      if (Object.keys(glidePhaseRef.current).length
+        && (!stillAnimating || now - glideLastWriteRef.current >= GLIDE_WRITE_INTERVAL_MS)) {
+        // the !stillAnimating write parks every copy at its exact final
+        // coordinates for the reconcile handoff
+        writeGlideSource();
+      }
     }
 
     if (hasTargets) {
@@ -177,12 +276,13 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       isAnimatingRef.current = false;
       animationFrameRef.current = null;
     }
-  }, [baseAnimationDuration, updateMapData]);
+  }, [baseAnimationDuration, updateMapData, writeGlideSource]);
 
   const updateAnimationState = useCallback((newPositions) => {
     const now = Date.now();
     const state = animationStateRef.current;
     let newTargetAdded = false;
+    const targetedIds = [];
 
     newPositions.forEach((position) => {
       const { deviceId, longitude, latitude, course } = position;
@@ -220,6 +320,12 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       if (isJump || !enableSmoothing) {
         state[deviceId] = { current: { longitude, latitude, rotation }, target: null, startTime: now, properties: position };
         lastUpdateTimeRef.current[deviceId] = now;
+        const phase = glidePhaseRef.current[deviceId];
+        if (phase === 'entering') {
+          delete glidePhaseRef.current[deviceId];
+        } else if (phase === 'active') {
+          glidePhaseRef.current[deviceId] = 'landed';
+        }
         return;
       }
 
@@ -234,6 +340,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         properties: position,
       };
       newTargetAdded = true;
+      targetedIds.push(deviceId);
     });
 
     const activeIds = new Set(newPositions.map((p) => p.deviceId));
@@ -244,14 +351,38 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         delete lastUpdateTimeRef.current[deviceId];
         delete lastCoordRef.current[deviceId];
         delete fixTimeCacheRef.current[deviceId];
+        if (glidePhaseRef.current[deviceId]) {
+          setTwinHidden(deviceId, false);
+          delete glidePhaseRef.current[deviceId];
+        }
       }
     });
+
+    if (targetedIds.length && Object.keys(state).length > PER_FRAME_WRITE_MAX_FLEET) {
+      let entered = false;
+      glideEligibleIds(targetedIds).forEach((deviceId) => {
+        const phase = glidePhaseRef.current[deviceId];
+        if (!phase) {
+          glidePhaseRef.current[deviceId] = 'entering';
+          entered = true;
+        } else if (phase === 'landed' || phase === 'reconciling') {
+          // re-glide before the reconcile swap finished: the twin is still
+          // hidden, so the copy just keeps moving
+          glidePhaseRef.current[deviceId] = 'active';
+        }
+      });
+      if (entered) {
+        // write the copy immediately so its features exist before the loaded
+        // event that hides the twins; until then both render at the same spot
+        writeGlideSource();
+      }
+    }
 
     if (newTargetAdded && !isAnimatingRef.current) {
       isAnimatingRef.current = true;
       animationFrameRef.current = requestAnimationFrame(animate);
     }
-  }, [enableSmoothing, calculateAnimationDuration, animate]);
+  }, [enableSmoothing, calculateAnimationDuration, animate, glideEligibleIds, setTwinHidden, writeGlideSource]);
 
   const onMouseEnter = () => { map.getCanvas().style.cursor = 'pointer'; };
   const onMouseLeave = () => { map.getCanvas().style.cursor = ''; };
@@ -304,8 +435,15 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       cluster: mapCluster,
       clusterMaxZoom: 14,
       clusterRadius: 50,
+      // stable per-device feature ids so feature-state can hide gliding twins
+      promoteId: 'deviceId',
     });
     map.addSource(selected, {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: [] },
+      promoteId: 'deviceId',
+    });
+    map.addSource(animating, {
       type: 'geojson',
       data: { type: 'FeatureCollection', features: [] },
     });
@@ -332,7 +470,8 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         paint: {
           'text-halo-color': 'white',
           'text-halo-width': 1,
-          'icon-opacity': 1,
+          'icon-opacity': hiddenWhenAnimating(1),
+          'text-opacity': hiddenWhenAnimating(1),
         },
       });
 
@@ -347,6 +486,9 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
           'icon-allow-overlap': true,
           'icon-rotate': ['get', 'rotation'],
           'icon-rotation-alignment': 'map',
+        },
+        paint: {
+          'icon-opacity': hiddenWhenAnimating(1),
         },
       });
       map.on('mouseenter', source, onMouseEnter);
@@ -376,14 +518,118 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     map.on('click', clusters, onClusterClick);
     map.on('click', onMapClick);
 
+    // mirror of the marker layers fed by the small glide source; inserted
+    // below the clusters layer so stacking matches the static markers
+    map.addLayer({
+      id: animating,
+      type: 'symbol',
+      source: animating,
+      layout: {
+        'icon-image': '{category}-{color}',
+        'icon-size': ['case', ['==', ['get', 'selected'], true], iconScale * 1.3, iconScale],
+        'icon-allow-overlap': true,
+        'text-field': `{${titleField || 'name'}}`,
+        'text-allow-overlap': true,
+        'text-anchor': 'bottom',
+        'text-offset': [0, -2 * iconScale],
+        'text-font': findFonts(map),
+        'text-size': 12,
+      },
+      paint: {
+        'text-halo-color': 'white',
+        'text-halo-width': 1,
+      },
+    }, clusters);
+    map.addLayer({
+      id: `direction-${animating}`,
+      type: 'symbol',
+      source: animating,
+      filter: ['==', 'direction', true],
+      layout: {
+        'icon-image': 'direction',
+        'icon-size': ['case', ['==', ['get', 'selected'], true], iconScale * 1.3, iconScale],
+        'icon-allow-overlap': true,
+        'icon-rotate': ['get', 'rotation'],
+        'icon-rotation-alignment': 'map',
+      },
+    }, clusters);
+    map.on('mouseenter', animating, onMouseEnter);
+    map.on('mouseleave', animating, onMouseLeave);
+    map.on('click', animating, onMarkerClick);
+
+    const onGlideSourceData = (event) => {
+      if (!event.isSourceLoaded) return;
+      const phases = glidePhaseRef.current;
+      if (event.sourceId === animating) {
+        // the copy is rendered from here on; hiding the twin in the same
+        // frame swaps them without a gap
+        Object.keys(phases).forEach((key) => {
+          if (phases[key] === 'entering') {
+            setTwinHidden(Number(key), true);
+            phases[key] = 'active';
+          }
+        });
+      } else if ((event.sourceId === id || event.sourceId === selected)
+        && map.getSource(id) && map.isSourceLoaded(id)
+        && map.getSource(selected) && map.isSourceLoaded(selected)) {
+        let removed = false;
+        Object.keys(phases).forEach((key) => {
+          if (phases[key] === 'reconciling') {
+            setTwinHidden(Number(key), false);
+            delete phases[key];
+            removed = true;
+          }
+        });
+        if (removed) writeGlideSourceRef.current();
+      }
+    };
+    map.on('sourcedata', onGlideSourceData);
+
+    const onGlideMoveEnd = () => {
+      const phases = glidePhaseRef.current;
+      const state = animationStateRef.current;
+      if (Object.keys(state).length <= PER_FRAME_WRITE_MAX_FLEET) return;
+      let changed = false;
+      // gliders that left the padded viewport swap back invisibly off-screen
+      const eligibleNow = new Set(glideEligibleIds(Object.keys(phases).map(Number)));
+      Object.keys(phases).map(Number).forEach((deviceId) => {
+        if (!eligibleNow.has(deviceId)) {
+          setTwinHidden(deviceId, false);
+          delete phases[deviceId];
+          changed = true;
+        }
+      });
+      // mid-glide devices that scrolled into view join the glide source
+      const midGlide = Object.keys(state)
+        .map(Number)
+        .filter((deviceId) => state[deviceId].target && !phases[deviceId]);
+      glideEligibleIds(midGlide).forEach((deviceId) => {
+        phases[deviceId] = 'entering';
+        changed = true;
+      });
+      if (changed) writeGlideSourceRef.current();
+    };
+    map.on('moveend', onGlideMoveEnd);
+
     return () => {
       if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
 
+      map.off('sourcedata', onGlideSourceData);
+      map.off('moveend', onGlideMoveEnd);
       map.off('mouseenter', clusters, onMouseEnter);
       map.off('mouseleave', clusters, onMouseLeave);
       map.off('click', clusters, onClusterClick);
       map.off('click', onMapClick);
       if (map.getLayer(clusters)) map.removeLayer(clusters);
+
+      map.off('mouseenter', animating, onMouseEnter);
+      map.off('mouseleave', animating, onMouseLeave);
+      map.off('click', animating, onMarkerClick);
+      if (map.getLayer(animating)) map.removeLayer(animating);
+      if (map.getLayer(`direction-${animating}`)) map.removeLayer(`direction-${animating}`);
+      if (map.getSource(animating)) map.removeSource(animating);
+      glidePhaseRef.current = {};
+      glideLastWriteRef.current = 0;
 
       [id, selected].forEach((source) => {
         map.off('mouseenter', source, onMouseEnter);
@@ -391,10 +637,13 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
         map.off('click', source, onMarkerClick);
         if (map.getLayer(source)) map.removeLayer(source);
         if (map.getLayer(`direction-${source}`)) map.removeLayer(`direction-${source}`);
-        if (map.getSource(source)) map.removeSource(source);
+        if (map.getSource(source)) {
+          map.removeFeatureState({ source });
+          map.removeSource(source);
+        }
       });
     };
-  }, [mapCluster, clusters, onMarkerClick, onClusterClick, iconScale, titleField, id, selected, onMapClick]);
+  }, [mapCluster, clusters, onMarkerClick, onClusterClick, iconScale, titleField, id, selected, animating, onMapClick, setTwinHidden, glideEligibleIds]);
 
   useEffect(() => {
     const filtered = positions.filter((p) => Object.prototype.hasOwnProperty.call(devices, p.deviceId));
@@ -409,8 +658,14 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   useEffect(() => {
     const faded = selectedPosition ? 0.5 : 1;
     if (map.getLayer(id)) {
-      map.setPaintProperty(id, 'icon-opacity', faded);
-      map.setPaintProperty(`direction-${id}`, 'icon-opacity', faded);
+      map.setPaintProperty(id, 'icon-opacity', hiddenWhenAnimating(faded));
+      map.setPaintProperty(`direction-${id}`, 'icon-opacity', hiddenWhenAnimating(faded));
+    }
+    if (map.getLayer(animating)) {
+      // the glide source mixes selected and non-selected devices; dim to match
+      const copyFaded = ['case', ['==', ['get', 'selected'], true], 1, faded];
+      map.setPaintProperty(animating, 'icon-opacity', copyFaded);
+      map.setPaintProperty(`direction-${animating}`, 'icon-opacity', copyFaded);
     }
   }, [selectedPosition?.deviceId]);
   return null;

--- a/src/map/MapPositions.writes.test.jsx
+++ b/src/map/MapPositions.writes.test.jsx
@@ -1,0 +1,284 @@
+/**
+ * Write-cadence harness for MapPositions at fleet scale.
+ *
+ * Drives the real component against a recording fake map with fake timers:
+ * 2,700 devices, one throttled flush every 1.5s, ~10% moving, ~150 devices
+ * individually rendered in the viewport (the rest clustered/off-screen).
+ *
+ * Every setData/updateData call on the fleet source re-tiles the whole source
+ * and restarts symbol placement in MapLibre (SourceCache.reload reloads every
+ * tile on any content update), so the steady-state contract asserted here is
+ * write AVOIDANCE: a flush where no render-relevant datum changed must produce
+ * zero fleet-source writes, and pure-motion churn must coalesce into rare
+ * deferred reconcile writes whose diff size is proportional to the number of
+ * changed devices, never the fleet.
+ */
+import React, { act } from 'react';
+import {
+  describe, it, expect, beforeAll, afterAll, vi,
+} from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+
+const { fake } = vi.hoisted(() => {
+  const handlers = new Map();
+  const sources = new Map();
+  const layers = new Map();
+  const fake = {
+    sourceOrder: [],
+    writes: [],
+    featureStateCalls: [],
+    renderedDeviceIds: new Set(),
+    reset() { this.writes = []; this.featureStateCalls = []; },
+  };
+  const fire = (event, payload) => {
+    const set = handlers.get(event);
+    if (set) [...set].forEach((h) => h(payload));
+  };
+  // real MapLibre acknowledges a write asynchronously after the worker
+  // round-trip; firing synchronously would let handlers observe state from
+  // before the write completed
+  const contentEvent = (sourceId) => setTimeout(() => fire('sourcedata', {
+    dataType: 'source', sourceDataType: 'content', sourceId, isSourceLoaded: true,
+  }), 0);
+  const makeSource = (id, def) => ({
+    _def: def,
+    setData(data) {
+      fake.writes.push({ sourceId: id, method: 'setData', count: data.features.length, features: data.features });
+      contentEvent(id);
+    },
+    updateData(diff) {
+      const count = (diff.add?.length || 0) + (diff.update?.length || 0) + (diff.remove?.length || 0);
+      fake.writes.push({ sourceId: id, method: 'updateData', count, diff });
+      contentEvent(id);
+    },
+  });
+  fake.map = {
+    addSource(id, def) { sources.set(id, makeSource(id, def)); fake.sourceOrder.push(id); },
+    getSource(id) { return sources.get(id); },
+    removeSource(id) { sources.delete(id); },
+    addLayer(def) { layers.set(def.id, def); },
+    getLayer(id) { return layers.get(id); },
+    removeLayer(id) { layers.delete(id); },
+    on(event, a, b) {
+      const key = b ? `${event}:${a}` : event;
+      if (!handlers.has(key)) handlers.set(key, new Set());
+      handlers.get(key).add(b || a);
+    },
+    off(event, a, b) {
+      const key = b ? `${event}:${a}` : event;
+      handlers.get(key)?.delete(b || a);
+    },
+    fire,
+    getBounds: () => ({
+      getWest: () => -10, getEast: () => 10, getSouth: () => -10, getNorth: () => 10,
+    }),
+    queryRenderedFeatures: () => [...fake.renderedDeviceIds].map((deviceId) => ({ properties: { deviceId } })),
+    setFeatureState(target, stateObj) { fake.featureStateCalls.push({ op: 'set', target, stateObj }); },
+    removeFeatureState(target, key) { fake.featureStateCalls.push({ op: 'remove', target, key }); },
+    isSourceLoaded: () => true,
+    getZoom: () => 10,
+    getCanvas: () => ({ style: {} }),
+    setPaintProperty: () => {},
+    easeTo: () => {},
+  };
+  return { fake };
+});
+
+vi.mock('./core/MapView', () => ({ map: fake.map }));
+vi.mock('./core/preloadImages', () => ({ mapIconKey: (category) => category || 'default' }));
+vi.mock('./core/mapUtil', () => ({ findFonts: () => ['Roboto Regular'] }));
+vi.mock('../common/util/preferences', () => ({
+  useAttributePreference: (key, defaultValue) => ({
+    mapCluster: true,
+    mapDirection: 'selected',
+    mapAnimationDuration: 2500,
+    mapEnableSmoothing: true,
+    mapAdaptiveTiming: true,
+    iconScale: 0.75,
+  }[key] ?? defaultValue),
+}));
+vi.mock('@mui/material', () => ({ useMediaQuery: () => true }));
+vi.mock('@mui/styles', () => ({ useTheme: () => ({ breakpoints: { up: () => 'md' } }) }));
+
+/* eslint-disable import/first */
+import MapPositions from './MapPositions';
+import { devicesReducer as devices, devicesActions } from '../store/devices';
+import { sessionReducer as session } from '../store/session';
+import { errorsReducer as errors } from '../store/errors';
+import { clustersReducer as clusters } from '../store/cluster';
+/* eslint-enable import/first */
+
+window.IS_REACT_ACT_ENVIRONMENT = true;
+
+const FLEET = 2700;
+const VISIBLE = 150;
+const FLUSH_MS = 1500;
+const MOVER_STRIDE = 10; // every 10th device moves => 270 movers, 15 of them visible
+const MOVE_STEP = 0.0008; // > MIN_CHANGE_DEG, < teleport threshold
+
+describe('MapPositions steady-state write cadence (2700 devices)', () => {
+  let store;
+  let root;
+  let container;
+  let posId = 1;
+  let simTime;
+  const coords = [];
+
+  const deviceList = Array.from({ length: FLEET }, (_, i) => ({
+    id: i + 1,
+    name: `Device ${i + 1}`,
+    category: 'car',
+    status: 'online',
+  }));
+
+  const makePositions = () => deviceList.map((device, i) => ({
+    id: (posId += 1),
+    deviceId: device.id,
+    longitude: coords[i].lng,
+    latitude: coords[i].lat,
+    course: 0,
+    accuracy: 0,
+    fixTime: new Date(simTime).toISOString(),
+    attributes: {},
+  }));
+
+  // stable like MainMap's memoized handler; an inline closure would re-run
+  // the structural effect (source teardown/re-add) on every render
+  const onClick = () => {};
+
+  const render = (positions, selectedPosition = null) => {
+    act(() => {
+      root.render(
+        <Provider store={store}>
+          <MapPositions positions={positions} onClick={onClick} showStatus selectedPosition={selectedPosition} />
+        </Provider>,
+      );
+    });
+  };
+
+  const flush = ({ movers = false } = {}) => {
+    simTime += FLUSH_MS;
+    if (movers) {
+      for (let i = 0; i < FLEET; i += MOVER_STRIDE) coords[i].lng += MOVE_STEP;
+    }
+    render(makePositions());
+    act(() => { vi.advanceTimersByTime(FLUSH_MS); });
+  };
+
+  const writesFor = (sourceId) => fake.writes.filter((w) => w.sourceId === sourceId);
+  const summarize = (label) => {
+    const bySource = {};
+    fake.writes.forEach((w) => {
+      const name = { 0: 'fleet', 1: 'selected', 2: 'glide' }[fake.sourceOrder.indexOf(w.sourceId)] || w.sourceId;
+      const key = `${name}/${w.method}`;
+      bySource[key] = bySource[key] || { writes: 0, features: 0, maxFeatures: 0 };
+      bySource[key].writes += 1;
+      bySource[key].features += w.count;
+      bySource[key].maxFeatures = Math.max(bySource[key].maxFeatures, w.count);
+    });
+    // eslint-disable-next-line no-console
+    console.log(`[write-cadence] ${label}`, JSON.stringify(bySource));
+    return bySource;
+  };
+
+  beforeAll(() => {
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date', 'performance', 'requestAnimationFrame', 'cancelAnimationFrame'],
+    });
+    vi.setSystemTime(new Date('2026-07-09T12:00:00Z'));
+    simTime = Date.now();
+
+    for (let i = 0; i < FLEET; i += 1) {
+      if (i < VISIBLE) {
+        coords.push({ lng: -5 + (i % 15) * 0.5, lat: -4 + Math.floor(i / 15) * 0.7 });
+      } else {
+        coords.push({ lng: 50 + (i % 50) * 0.5, lat: 20 + Math.floor(i / 50) * 0.3 });
+      }
+    }
+    for (let i = 0; i < VISIBLE; i += 1) fake.renderedDeviceIds.add(i + 1);
+
+    store = configureStore({ reducer: combineReducers({ devices, session, errors, clusters }) });
+    store.dispatch(devicesActions.refresh(deviceList));
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterAll(() => {
+    act(() => { root.unmount(); });
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('initial load performs one full setData per marker source', () => {
+    render(makePositions());
+    act(() => { vi.advanceTimersByTime(50); });
+    const fleet = writesFor(fake.sourceOrder[0]);
+    summarize('initial');
+    expect(fleet.length).toBeGreaterThanOrEqual(1);
+    expect(fleet[0].method).toBe('setData');
+    expect(fleet[0].count).toBe(FLEET);
+    fake.reset();
+  });
+
+  it('30s of stationary fleet with fresh fixTime/position ids produces zero marker-source writes', () => {
+    for (let n = 0; n < 20; n += 1) flush();
+    const stats = summarize('static-30s');
+    expect(writesFor(fake.sourceOrder[0]).length).toBe(0);
+    expect(writesFor(fake.sourceOrder[1]).length).toBe(0);
+    expect(stats).toBeDefined();
+    fake.reset();
+  });
+
+  it('30s with 10% moving coalesces fleet writes into rare diffs proportional to changed devices', () => {
+    for (let n = 0; n < 20; n += 1) flush({ movers: true });
+    summarize('moving-30s');
+    const fleetWrites = writesFor(fake.sourceOrder[0]);
+    // deferred reconcile cadence: ~2 writes in 30s, not one per flush/second
+    expect(fleetWrites.length).toBeGreaterThanOrEqual(1);
+    expect(fleetWrites.length).toBeLessThanOrEqual(4);
+    fleetWrites.forEach((w) => {
+      expect(w.method).toBe('updateData');
+      // diff size ~ number of movers (270), never the fleet
+      expect(w.count).toBeLessThanOrEqual(FLEET / 4);
+    });
+    // motion still renders: the glide source carried the visible movers
+    expect(writesFor(fake.sourceOrder[2]).length).toBeGreaterThan(0);
+    fake.reset();
+  });
+
+  it('selecting a device moves exactly one feature between sources as a diff', () => {
+    // drain the deferred backlog left by the moving phase so the selection
+    // write is not also carrying piggybacked reconcile features
+    for (let n = 0; n < 12; n += 1) flush();
+    fake.reset();
+    act(() => { store.dispatch(devicesActions.selectId(3)); });
+    const selectedWrites = writesFor(fake.sourceOrder[1]);
+    const fleetWrites = writesFor(fake.sourceOrder[0]);
+    summarize('selection');
+    expect(selectedWrites.length).toBe(1);
+    expect(selectedWrites[0].method).toBe('updateData');
+    expect(selectedWrites[0].count).toBe(1);
+    expect(fleetWrites.length).toBe(1);
+    expect(fleetWrites[0].method).toBe('updateData');
+    expect(fleetWrites[0].count).toBe(1);
+    act(() => { store.dispatch(devicesActions.selectId(null)); });
+    fake.reset();
+  });
+
+  it('when motion stops, the landing flush reconciles and empties the glide source', () => {
+    // one more moving flush, then quiet flushes so every glide lands
+    flush({ movers: true });
+    for (let n = 0; n < 14; n += 1) flush();
+    summarize('stop-motion');
+    const glideWrites = writesFor(fake.sourceOrder[2]);
+    expect(glideWrites.length).toBeGreaterThan(0);
+    expect(glideWrites[glideWrites.length - 1].count).toBe(0);
+    // twins were unhidden after the reconcile write landed
+    expect(fake.featureStateCalls.some((c) => c.op === 'remove')).toBe(true);
+    fake.reset();
+  });
+});

--- a/src/map/core/MapView.jsx
+++ b/src/map/core/MapView.jsx
@@ -13,6 +13,7 @@ import usePersistedState, { savePersistedState } from '../../common/util/usePers
 import { mapImages } from './preloadImages';
 import useMapStyles, { mapBackgroundColor } from './useMapStyles';
 import { FullScreenControl } from '../controls/MapFullScreen';
+import { attachMapWriteDebug } from './mapWriteDebug';
 
 const element = document.createElement('div');
 element.style.width = '100%';
@@ -51,6 +52,8 @@ export const map = new maplibregl.Map({
     zoom: initialCamera.zoom,
   }),
 });
+
+attachMapWriteDebug(map);
 
 map.on('moveend', () => {
   const zoom = map.getZoom();

--- a/src/map/core/mapWriteDebug.js
+++ b/src/map/core/mapWriteDebug.js
@@ -1,0 +1,156 @@
+/* eslint-disable no-console */
+
+// Instrumentation for correlating visible marker blinks with GeoJSON source
+// writes. Off by default; when off every exported hook is a single boolean
+// check. Enable with ?mapWriteDebug=1 (persisted to localStorage) or from the
+// console with mapWriteDebug.enable(); disable with mapWriteDebug.disable().
+//
+// When enabled it records, with timestamps:
+//  - every source write (setData/updateData): source label, feature count,
+//    trigger ('flush' / 'animation' / 'landing' / 'selection' / ...);
+//  - every 'sourcedata' event with sourceDataType === 'content' for the
+//    registered sources (one fires when the worker acknowledges each write);
+//  - an on-screen flash indicator so blink moments can be matched to write
+//    moments by eye. The ring buffer is at mapWriteDebug.events.
+
+const STORAGE_KEY = 'mapWriteDebug';
+const RING_LIMIT = 2000;
+
+const SOURCE_COLORS = {
+  fleet: '#e53935',
+  selected: '#fb8c00',
+  glide: '#1e88e5',
+  accuracy: '#8e24aa',
+};
+
+const readInitialFlag = () => {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get(STORAGE_KEY) === '1') {
+      window.localStorage.setItem(STORAGE_KEY, '1');
+      return true;
+    }
+    if (params.get(STORAGE_KEY) === '0') {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return false;
+    }
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const state = {
+  enabled: false,
+  map: null,
+  attached: false,
+  registry: new Map(), // sourceId -> label
+  events: [],
+  indicator: null,
+  indicatorTimer: null,
+};
+
+const wallClock = () => new Date().toISOString().slice(11, 23);
+
+const record = (entry) => {
+  state.events.push(entry);
+  if (state.events.length > RING_LIMIT) {
+    state.events.splice(0, state.events.length - RING_LIMIT);
+  }
+};
+
+const flashIndicator = (label, text) => {
+  if (!state.indicator) {
+    const el = document.createElement('div');
+    el.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:10000;'
+      + 'font:11px/1.4 monospace;color:#fff;background:#616161;padding:2px 8px;'
+      + 'border-radius:4px;pointer-events:none;opacity:0.9;';
+    document.body.appendChild(el);
+    state.indicator = el;
+  }
+  state.indicator.style.background = SOURCE_COLORS[label] || '#616161';
+  state.indicator.textContent = text;
+  if (state.indicatorTimer) clearTimeout(state.indicatorTimer);
+  state.indicatorTimer = setTimeout(() => {
+    if (state.indicator) state.indicator.style.background = '#333';
+  }, 250);
+};
+
+const onSourceData = (event) => {
+  if (!state.enabled) return;
+  if (event.dataType !== 'source' || event.sourceDataType !== 'content') return;
+  const label = state.registry.get(event.sourceId);
+  if (!label) return;
+  const t = performance.now();
+  record({ t, wall: wallClock(), kind: 'content', source: label, loaded: event.isSourceLoaded });
+  console.log(`[mapwrite] ${wallClock()} content   ${label} (isSourceLoaded=${event.isSourceLoaded})`);
+};
+
+const attach = () => {
+  if (state.attached || !state.map) return;
+  state.map.on('sourcedata', onSourceData);
+  state.attached = true;
+};
+
+// Called once from MapView after the map singleton is created.
+export const attachMapWriteDebug = (map) => {
+  state.map = map;
+  if (state.enabled) attach();
+};
+
+// Sources register a stable human label ('fleet', 'selected', 'glide', ...)
+// so log lines and sourcedata events are readable despite useId-based ids.
+export const registerMapWriteDebugSource = (sourceId, label) => {
+  state.registry.set(sourceId, label);
+};
+
+export const unregisterMapWriteDebugSource = (sourceId) => {
+  state.registry.delete(sourceId);
+};
+
+// The single hot-path hook: call at every setData/updateData call site.
+export const logMapWrite = (sourceId, method, featureCount, trigger) => {
+  if (!state.enabled) return;
+  const label = state.registry.get(sourceId) || sourceId;
+  const t = performance.now();
+  record({ t, wall: wallClock(), kind: 'write', source: label, method, featureCount, trigger });
+  console.log(`[mapwrite] ${wallClock()} ${method.padEnd(10)}${label} n=${featureCount} (${trigger})`);
+  flashIndicator(label, `${label} ${method} n=${featureCount} ${trigger}`);
+};
+
+const summary = (sinceSeconds = 60) => {
+  const cutoff = performance.now() - sinceSeconds * 1000;
+  const recent = state.events.filter((e) => e.t >= cutoff && e.kind === 'write');
+  const bySource = {};
+  recent.forEach((e) => {
+    const key = `${e.source}/${e.method}`;
+    bySource[key] = bySource[key] || { writes: 0, features: 0, triggers: {} };
+    bySource[key].writes += 1;
+    bySource[key].features += e.featureCount;
+    bySource[key].triggers[e.trigger] = (bySource[key].triggers[e.trigger] || 0) + 1;
+  });
+  return { windowSeconds: sinceSeconds, totalWrites: recent.length, bySource };
+};
+
+const controls = {
+  enable: () => {
+    state.enabled = true;
+    try { window.localStorage.setItem(STORAGE_KEY, '1'); } catch { /* private mode */ }
+    attach();
+    console.log('[mapwrite] enabled');
+  },
+  disable: () => {
+    state.enabled = false;
+    try { window.localStorage.removeItem(STORAGE_KEY); } catch { /* private mode */ }
+    console.log('[mapwrite] disabled');
+  },
+  summary,
+  get events() { return state.events; },
+};
+
+if (typeof window !== 'undefined') {
+  window.mapWriteDebug = controls;
+  state.enabled = readInitialFlag();
+}
+
+export default controls;

--- a/src/map/core/mapWriteDebug.js
+++ b/src/map/core/mapWriteDebug.js
@@ -2,8 +2,11 @@
 
 // Instrumentation for correlating visible marker blinks with GeoJSON source
 // writes. Off by default; when off every exported hook is a single boolean
-// check. Enable with ?mapWriteDebug=1 (persisted to localStorage) or from the
-// console with mapWriteDebug.enable(); disable with mapWriteDebug.disable().
+// check, no listener does work, and no DOM exists. Enable for the current
+// session only with ?mapWriteDebug=1 or mapWriteDebug.enable(); surviving
+// reloads is an explicit opt-in via mapWriteDebug.enable({ persist: true }).
+// mapWriteDebug.disable() removes the on-screen indicator immediately and
+// clears any persisted opt-in (?mapWriteDebug=0 also clears it).
 //
 // When enabled it records, with timestamps:
 //  - every source write (setData/updateData): source label, feature count,
@@ -33,10 +36,10 @@ const SOURCE_COLORS = {
 const readInitialFlag = () => {
   try {
     const params = new URLSearchParams(window.location.search);
-    if (params.get(STORAGE_KEY) === '1') {
-      window.localStorage.setItem(STORAGE_KEY, '1');
-      return true;
-    }
+    // the query param is session-only by design: persisting it here is how a
+    // one-off field-verification run used to leave debug on for every later
+    // session in that browser. Only enable({ persist: true }) writes storage.
+    if (params.get(STORAGE_KEY) === '1') return true;
     if (params.get(STORAGE_KEY) === '0') {
       window.localStorage.removeItem(STORAGE_KEY);
       return false;
@@ -66,9 +69,12 @@ const record = (entry) => {
   }
 };
 
+// The indicator is created lazily on the first logged write while enabled,
+// so a disabled session never puts anything in the DOM.
 const flashIndicator = (label, text) => {
   if (!state.indicator) {
     const el = document.createElement('div');
+    el.setAttribute('data-mapwrite-indicator', '1');
     el.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:10000;'
       + 'font:11px/1.4 monospace;color:#fff;background:#616161;padding:2px 8px;'
       + 'border-radius:4px;pointer-events:none;opacity:0.9;';
@@ -81,6 +87,17 @@ const flashIndicator = (label, text) => {
   state.indicatorTimer = setTimeout(() => {
     if (state.indicator) state.indicator.style.background = '#333';
   }, 250);
+};
+
+const removeIndicator = () => {
+  if (state.indicatorTimer) {
+    clearTimeout(state.indicatorTimer);
+    state.indicatorTimer = null;
+  }
+  if (state.indicator) {
+    state.indicator.remove();
+    state.indicator = null;
+  }
 };
 
 const onSourceData = (event) => {
@@ -97,6 +114,12 @@ const attach = () => {
   if (state.attached || !state.map) return;
   state.map.on('sourcedata', onSourceData);
   state.attached = true;
+};
+
+const detach = () => {
+  if (!state.attached || !state.map) return;
+  state.map.off('sourcedata', onSourceData);
+  state.attached = false;
 };
 
 // Called once from MapView after the map singleton is created.
@@ -157,14 +180,20 @@ const summary = (sinceSeconds = 60) => {
 };
 
 const controls = {
-  enable: () => {
+  enable: (options = {}) => {
     state.enabled = true;
-    try { window.localStorage.setItem(STORAGE_KEY, '1'); } catch { /* private mode */ }
+    if (options.persist) {
+      try { window.localStorage.setItem(STORAGE_KEY, '1'); } catch { /* private mode */ }
+    }
     attach();
-    console.log('[mapwrite] enabled');
+    console.log(options.persist
+      ? '[mapwrite] enabled (persisted; survives reloads until disable())'
+      : '[mapwrite] enabled (this session only; enable({ persist: true }) to survive reloads)');
   },
   disable: () => {
     state.enabled = false;
+    removeIndicator();
+    detach();
     try { window.localStorage.removeItem(STORAGE_KEY); } catch { /* private mode */ }
     console.log('[mapwrite] disabled');
   },

--- a/src/map/core/mapWriteDebug.js
+++ b/src/map/core/mapWriteDebug.js
@@ -7,9 +7,16 @@
 //
 // When enabled it records, with timestamps:
 //  - every source write (setData/updateData): source label, feature count,
-//    trigger ('flush' / 'animation' / 'landing' / 'selection' / ...);
+//    trigger — one of 'load' (first full write after source creation),
+//    'flush-urgent' (visible change written within its flush),
+//    'reconcile-15s' (deferred invisible-motion backlog on its interval),
+//    'moveend', 'selection', 'glide', 'hard-reset' (derived-prop change or
+//    fleet-size branch crossing forced a full rewrite);
 //  - every 'sourcedata' event with sourceDataType === 'content' for the
 //    registered sources (one fires when the worker acknowledges each write);
+//  - every registered source add/remove (register/unregister run right where
+//    addSource/removeSource do), so "zero teardowns in steady state" is
+//    directly observable instead of inferred from blink character;
 //  - an on-screen flash indicator so blink moments can be matched to write
 //    moments by eye. The ring buffer is at mapWriteDebug.events.
 
@@ -100,12 +107,21 @@ export const attachMapWriteDebug = (map) => {
 
 // Sources register a stable human label ('fleet', 'selected', 'glide', ...)
 // so log lines and sourcedata events are readable despite useId-based ids.
+// Registration doubles as the source-lifecycle log: components call these in
+// the same effect that runs addSource/removeSource.
 export const registerMapWriteDebugSource = (sourceId, label) => {
   state.registry.set(sourceId, label);
+  if (!state.enabled) return;
+  record({ t: performance.now(), wall: wallClock(), kind: 'lifecycle', source: label, event: 'add' });
+  console.log(`[mapwrite] ${wallClock()} addSource ${label}`);
 };
 
 export const unregisterMapWriteDebugSource = (sourceId) => {
+  const label = state.registry.get(sourceId) || sourceId;
   state.registry.delete(sourceId);
+  if (!state.enabled) return;
+  record({ t: performance.now(), wall: wallClock(), kind: 'lifecycle', source: label, event: 'remove' });
+  console.log(`[mapwrite] ${wallClock()} removeSource ${label}`);
 };
 
 // The single hot-path hook: call at every setData/updateData call site.
@@ -120,16 +136,24 @@ export const logMapWrite = (sourceId, method, featureCount, trigger) => {
 
 const summary = (sinceSeconds = 60) => {
   const cutoff = performance.now() - sinceSeconds * 1000;
-  const recent = state.events.filter((e) => e.t >= cutoff && e.kind === 'write');
+  const recent = state.events.filter((e) => e.t >= cutoff);
+  const writes = recent.filter((e) => e.kind === 'write');
   const bySource = {};
-  recent.forEach((e) => {
+  writes.forEach((e) => {
     const key = `${e.source}/${e.method}`;
     bySource[key] = bySource[key] || { writes: 0, features: 0, triggers: {} };
     bySource[key].writes += 1;
     bySource[key].features += e.featureCount;
     bySource[key].triggers[e.trigger] = (bySource[key].triggers[e.trigger] || 0) + 1;
   });
-  return { windowSeconds: sinceSeconds, totalWrites: recent.length, bySource };
+  // steady state must show zero entries here; any '<label>/remove' means the
+  // structural effect tore a source down mid-session
+  const lifecycle = {};
+  recent.filter((e) => e.kind === 'lifecycle').forEach((e) => {
+    const key = `${e.source}/${e.event}`;
+    lifecycle[key] = (lifecycle[key] || 0) + 1;
+  });
+  return { windowSeconds: sinceSeconds, totalWrites: writes.length, bySource, lifecycle };
 };
 
 const controls = {

--- a/src/map/core/mapWriteDebug.test.js
+++ b/src/map/core/mapWriteDebug.test.js
@@ -1,0 +1,102 @@
+/**
+ * Contract tests for the mapWriteDebug instrument: off by default with zero
+ * DOM and zero console output, ?mapWriteDebug=1 enables the current session
+ * WITHOUT persisting, persistence only via enable({ persist: true }), and
+ * disable() removes the indicator immediately and clears storage.
+ *
+ * readInitialFlag runs at module load, so every scenario imports a fresh
+ * module instance after arranging the URL and localStorage.
+ */
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+
+const STORAGE_KEY = 'mapWriteDebug';
+const INDICATOR = '[data-mapwrite-indicator]';
+
+let logSpy;
+
+const mapwriteLogs = () => logSpy.mock.calls.filter((c) => String(c[0]).startsWith('[mapwrite]'));
+
+const freshModule = async ({ search = '', storage = null } = {}) => {
+  vi.resetModules();
+  window.history.replaceState({}, '', `/${search}`);
+  window.localStorage.clear();
+  if (storage !== null) window.localStorage.setItem(STORAGE_KEY, storage);
+  return import('./mapWriteDebug');
+};
+
+// a steady-state-shaped sequence: sources registered, then a run of writes
+const simulateFlushSequence = (mod) => {
+  mod.registerMapWriteDebugSource('src-1', 'fleet');
+  mod.registerMapWriteDebugSource('src-2', 'selected');
+  mod.registerMapWriteDebugSource('src-3', 'glide');
+  for (let n = 0; n < 40; n += 1) {
+    mod.logMapWrite('src-1', 'updateData', 4, 'flush-urgent');
+    mod.logMapWrite('src-3', 'setData', 1, 'glide');
+  }
+};
+
+describe('mapWriteDebug enablement contract', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    document.querySelectorAll(INDICATOR).forEach((el) => el.remove());
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
+    logSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('disabled by default: a full flush sequence produces zero DOM nodes, zero console output, clean storage', async () => {
+    const mod = await freshModule();
+    simulateFlushSequence(mod);
+    vi.runAllTimers();
+    expect(document.querySelector(INDICATOR)).toBeNull();
+    expect(mapwriteLogs().length).toBe(0);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('?mapWriteDebug=1 enables this session only and does NOT persist', async () => {
+    const mod = await freshModule({ search: '?mapWriteDebug=1' });
+    simulateFlushSequence(mod);
+    expect(document.querySelector(INDICATOR)).not.toBeNull();
+    expect(mapwriteLogs().length).toBeGreaterThan(0);
+    // the regression: this used to write '1' and re-enable every later session
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('a previously persisted opt-in still enables at boot', async () => {
+    const mod = await freshModule({ storage: '1' });
+    simulateFlushSequence(mod);
+    expect(document.querySelector(INDICATOR)).not.toBeNull();
+  });
+
+  it('enable() is session-only; enable({ persist: true }) is the explicit opt-in', async () => {
+    const mod = await freshModule();
+    mod.default.enable();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    mod.default.enable({ persist: true });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1');
+  });
+
+  it('disable() removes the indicator immediately, clears storage, and silences further writes', async () => {
+    const mod = await freshModule();
+    mod.default.enable({ persist: true });
+    simulateFlushSequence(mod);
+    expect(document.querySelector(INDICATOR)).not.toBeNull();
+
+    mod.default.disable();
+    expect(document.querySelector(INDICATOR)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    const logsAfterDisable = mapwriteLogs().length;
+    simulateFlushSequence(mod);
+    vi.runAllTimers();
+    expect(document.querySelector(INDICATOR)).toBeNull();
+    expect(mapwriteLogs().length).toBe(logsAfterDisable);
+  });
+});

--- a/src/map/main/MapAccuracy.js
+++ b/src/map/main/MapAccuracy.js
@@ -6,7 +6,10 @@ import { logMapWrite, registerMapWriteDebugSource, unregisterMapWriteDebugSource
 
 const MapAccuracy = ({ positions }) => {
   const id = useId();
-  const lastSignatureRef = useRef(null);
+  // starts as the signature of an empty collection: a fleet with no accuracy
+  // circles never writes at all (the source is created empty already)
+  const lastSignatureRef = useRef('');
+  const hasWrittenRef = useRef(false);
 
   const theme = useTheme();
 
@@ -63,7 +66,8 @@ const MapAccuracy = ({ positions }) => {
       type: 'FeatureCollection',
       features,
     });
-    logMapWrite(id, 'setData', features.length, 'flush');
+    logMapWrite(id, 'setData', features.length, hasWrittenRef.current ? 'flush-urgent' : 'load');
+    hasWrittenRef.current = true;
   }, [positions]);
 
   return null;

--- a/src/map/main/MapAccuracy.js
+++ b/src/map/main/MapAccuracy.js
@@ -2,6 +2,7 @@ import { useId, useEffect } from 'react';
 import circle from '@turf/circle';
 import { useTheme } from '@mui/styles';
 import { map } from '../core/MapView';
+import { logMapWrite, registerMapWriteDebugSource, unregisterMapWriteDebugSource } from '../core/mapWriteDebug';
 
 const MapAccuracy = ({ positions }) => {
   const id = useId();
@@ -16,6 +17,7 @@ const MapAccuracy = ({ positions }) => {
         features: [],
       },
     });
+    registerMapWriteDebugSource(id, 'accuracy');
     map.addLayer({
       source: id,
       id,
@@ -32,6 +34,7 @@ const MapAccuracy = ({ positions }) => {
     });
 
     return () => {
+      unregisterMapWriteDebugSource(id);
       if (map.getLayer(id)) {
         map.removeLayer(id);
       }
@@ -42,12 +45,14 @@ const MapAccuracy = ({ positions }) => {
   }, []);
 
   useEffect(() => {
+    const features = positions
+      .filter((position) => position.accuracy > 0)
+      .map((position) => circle([position.longitude, position.latitude], position.accuracy * 0.001));
     map.getSource(id)?.setData({
       type: 'FeatureCollection',
-      features: positions
-        .filter((position) => position.accuracy > 0)
-        .map((position) => circle([position.longitude, position.latitude], position.accuracy * 0.001)),
+      features,
     });
+    logMapWrite(id, 'setData', features.length, 'flush');
   }, [positions]);
 
   return null;

--- a/src/map/main/MapAccuracy.js
+++ b/src/map/main/MapAccuracy.js
@@ -1,4 +1,4 @@
-import { useId, useEffect } from 'react';
+import { useId, useEffect, useRef } from 'react';
 import circle from '@turf/circle';
 import { useTheme } from '@mui/styles';
 import { map } from '../core/MapView';
@@ -6,6 +6,7 @@ import { logMapWrite, registerMapWriteDebugSource, unregisterMapWriteDebugSource
 
 const MapAccuracy = ({ positions }) => {
   const id = useId();
+  const lastSignatureRef = useRef(null);
 
   const theme = useTheme();
 
@@ -45,10 +46,20 @@ const MapAccuracy = ({ positions }) => {
   }, []);
 
   useEffect(() => {
-    const features = positions
-      .filter((position) => position.accuracy > 0)
+    // the positions array gets a new identity every WS flush even when no
+    // device moved; every setData re-tiles the source, so skip the write (and
+    // the turf circle generation) unless an accuracy circle actually changed
+    const relevant = positions.filter((position) => position.accuracy > 0);
+    const signature = relevant
+      .map((p) => `${p.deviceId}:${p.longitude}:${p.latitude}:${p.accuracy}`)
+      .join('|');
+    if (signature === lastSignatureRef.current) return;
+    const sourceObj = map.getSource(id);
+    if (!sourceObj) return;
+    lastSignatureRef.current = signature;
+    const features = relevant
       .map((position) => circle([position.longitude, position.latitude], position.accuracy * 0.001));
-    map.getSource(id)?.setData({
+    sourceObj.setData({
       type: 'FeatureCollection',
       features,
     });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,25 @@
+import { execSync } from 'node:child_process';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import { VitePWA } from 'vite-plugin-pwa';
 
+// build-identity stamp: logged at boot so the deployed commit is always
+// answerable from the browser console (stale-service-worker incidents made
+// "which ref is this bundle" a recurring debugging cost)
+const gitCommit = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+})();
+
 /* eslint-disable no-template-curly-in-string */
 export default defineConfig(() => ({
+  define: {
+    __GIT_COMMIT__: JSON.stringify(gitCommit),
+  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## Root cause (prod traces + git archaeology)

Commit 25f20e1d (release-2 only) retuned throttleMiddleware (maxInterval 30000→5000, scaleFactor 1000→20), raising store flush cadence under load from ~30s to 1.5–5s. That kept MapPositions' pre-existing 60fps smoothing loop permanently mid-glide (adaptive duration = gap×0.8), so it replaced both GeoJSON marker sources via setData on every animation frame — constant worker re-tiling + symbol placement restarts, which renders as fleet-wide marker blinking (`fadeDuration: 0` from #170 was deployed in the traced bundle and did not stop it) — and re-ran formatTime (dayjs parse + Intl) for all ~2,700 devices every frame (measured 107.9 ms per full-fleet pass), causing the 100–646 ms long tasks in the traces.

## Fixes

**d992ef80 — stop the flicker (root cause)**
- Animation-driven full-source writes gated to 1/s above 300 devices, with a guaranteed landing write; fleets ≤300 and Replay keep per-frame behavior.
- formatTime cached per device keyed by raw fixTime.
- Measured: ~98 setData/s → 4/s; full-fleet format pass 107.9 ms → 0.05 ms.

**3efb19c6 — restore smooth glide for large fleets**
- Gliding devices (new position ∩ padded viewport ∩ individually rendered) animate through a small dedicated GeoJSON source written at ≤15fps — cost is O(gliding devices), typically tens of features.
- Their static twin in the full source is hidden via feature-state (`promoteId: deviceId`) wrapped into icon-/text-opacity — paint-only, no worker round-trip; cluster membership and counts are unaffected.
- Gap-free handoffs by ordering: the copy is written before twins hide (swap on the copy source's loaded event); twins un-hide only after the reconcile write containing the final position reports loaded, then the copy drops out.
- Selected device glides through the same source at 1.3× via data-driven icon-size; status-card dimming mirrored.
- Gliding set recomputed on moveend; devices inside clusters or off-viewport keep snapping at the reconcile cadence (not individually visible anyway).
- Main-source cadence unchanged (2.0/s simulated); glide source 12.3/s with 14–15 features per write; ~0.02 ms JS per glide write.

## Verification
- eslint clean; vitest 20/20 (note: CI runs lint only — no test job).
- Cadence and cost measurements from a 30s simulation (2,700 devices, flush/1.5s, 10% moving, ~150 visible) — numbers above.
- Needs staging confirmation with a live feed: single vehicle glides smoothly through several update cycles with no jump-back or double marker at start/landing; no fleet-wide blink during WS bursts; clicking a gliding marker opens the status card; cluster counts stay correct while nearby markers glide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)