### PR TITLE
`changes addded on onClusterClick`

### DIFF
--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -14,6 +14,7 @@ import { makeStyles } from '@mui/styles';
 import { clustersActions } from '../store/cluster';
 import { devicesActions } from '../store/devices';
 import { map } from '../map/core/MapView';
+import { CLUSTER_POPUP_MAX_METERS_PER_PIXEL } from '../map/MapPositions';
 import { useTranslation } from '../common/components/LocalizationProvider';
 import { formatStatus } from '../common/util/formatter';
 
@@ -187,8 +188,7 @@ const ClusterPopup = () => {
 
     const handleZoomOut = () => {
       const metersPerPixel = (156543.03392 * Math.cos((map.getCenter().lat * Math.PI) / 180)) / (2 ** map.getZoom());
-      const visibleWidthKm = (map.getCanvas().width * metersPerPixel) / 1000;
-      if (visibleWidthKm > 739) hide();
+      if (metersPerPixel > CLUSTER_POPUP_MAX_METERS_PER_PIXEL) hide();
     };
 
     map.on('click', hide);

--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  Box, Typography, IconButton, Paper, ListItem, ListItemText,
+  Box, Typography, IconButton, Paper, ListItem,
 } from '@mui/material';
 import { FixedSizeList } from 'react-window';
 import CloseIcon from '@mui/icons-material/Close';

--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -9,7 +9,6 @@ import { FixedSizeList } from 'react-window';
 import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import { makeStyles } from '@mui/styles';
 import { clustersActions } from '../store/cluster';
 import { devicesActions } from '../store/devices';
@@ -110,9 +109,9 @@ const ClusterDeviceRow = ({ data, index, style }) => {
     >
       <Box
         sx={{
-          display: "flex",
-          alignItems: "center",
-          width: "100%",
+          display: 'flex',
+          alignItems: 'center',
+          width: '100%',
           gap: 1,
         }}
       >
@@ -140,16 +139,10 @@ const ClusterDeviceRow = ({ data, index, style }) => {
 
         <IconButton
           size="small"
+          title={t('sharedShowDetails')}
           onClick={() => onSelect(device.id)}
         >
           <InfoOutlinedIcon fontSize="small" />
-        </IconButton>
-
-        <IconButton
-          size="small"
-          onClick={() => onSelect(device.id)}
-        >
-          <GpsFixedIcon fontSize="small" />
         </IconButton>
       </Box>
     </ListItem>

--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -103,41 +103,54 @@ const ClusterDeviceRow = ({ data, index, style }) => {
   const device = devices[index];
   return (
     <ListItem
-      component="div"
-      dense
       divider={index < devices.length - 1}
       style={style}
       className={classes.listItem}
-      secondaryAction={(
-        <>
-          <IconButton
-            size="small"
-            title={t('sharedShowDetails')}
-            onClick={() => onSelect(device.id)}
-          >
-            <InfoOutlinedIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            title={t('startTracking')}
-            onClick={() => onSelect(device.id)}
-          >
-            <GpsFixedIcon fontSize="small" />
-          </IconButton>
-        </>
-      )}
     >
-      <ListItemText
-        primary={device.name}
-        secondary={formatStatus(device.status, t)}
-        primaryTypographyProps={{
-          noWrap: true,
-          className: classes.deviceName,
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          width: "100%",
+          gap: 1,
         }}
-        secondaryTypographyProps={{
-          noWrap: true,
-        }}
-      />
+      >
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          <Typography
+            noWrap
+            className={classes.deviceName}
+          >
+            {device.name}
+          </Typography>
+
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            noWrap
+          >
+            {formatStatus(device.status, t)}
+          </Typography>
+        </Box>
+
+        <IconButton
+          size="small"
+          onClick={() => onSelect(device.id)}
+        >
+          <InfoOutlinedIcon fontSize="small" />
+        </IconButton>
+
+        <IconButton
+          size="small"
+          onClick={() => onSelect(device.id)}
+        >
+          <GpsFixedIcon fontSize="small" />
+        </IconButton>
+      </Box>
     </ListItem>
   );
 };

--- a/src/main/ClusterPopUp.jsx
+++ b/src/main/ClusterPopUp.jsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const INITIAL_BOTTOM = 16;
-const ROW_HEIGHT = 61;
+const ROW_HEIGHT = 68;
 const LIST_MAX_HEIGHT = 340;
 
 const ClusterDeviceRow = ({ data, index, style }) => {

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -15,6 +15,10 @@ import { clustersActions } from '../store/cluster';
 
 const CLUSTER_POPUP_MIN_ZOOM = 9;
 
+// Coarser than this scale (~5 km across a typical viewport) the popup covers
+// too large an area to be meaningful, so cluster clicks zoom in instead.
+export const CLUSTER_POPUP_MAX_METERS_PER_PIXEL = 50;
+
 const TELEPORT_THRESHOLD_SQ = 0.0045 * 0.0045;
 const STALE_GAP_MS = 10000;
 const MIN_CHANGE_DEG = 0.000005;
@@ -251,11 +255,10 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const pointCount = clusterFeature.properties.point_count; // ← already available
 
     const metersPerPixel = (156543.03392 * Math.cos((clusterCoords[1] * Math.PI) / 180)) / (2 ** map.getZoom());
-    const visibleWidthKm = (map.getCanvas().width * metersPerPixel) / 1000;
 
     const zoom = await map.getSource(id).getClusterExpansionZoom(clusterId);
 
-    if (visibleWidthKm > 739 || pointCount < 10) {
+    if (metersPerPixel > CLUSTER_POPUP_MAX_METERS_PER_PIXEL || pointCount < 10) {
       map.easeTo({ center: clusterCoords, zoom });
       return;
     }
@@ -282,8 +285,6 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       devices: clusterDevices,
       coordinates: clusterCoords,
     }));
-
-    map.easeTo({ center: clusterCoords, zoom });
   }, [clusters, positions, devices]);
 
   useEffect(() => {

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -378,6 +378,10 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   useEffect(() => {
     const filtered = positions.filter((p) => Object.prototype.hasOwnProperty.call(devices, p.deviceId));
     updateAnimationState(filtered);
+    // Always push current state to the map sources. The animation loop only
+    // runs for devices that moved, so with smoothing enabled the initial
+    // positions would otherwise never reach the sources and no markers or
+    // clusters would render until something else called updateMapData.
     updateMapData();
   }, [positions, devices, enableSmoothing, updateAnimationState, updateMapData]);
 

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -241,7 +241,6 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
 
   const onClusterClick = useCatchCallback(async (event) => {
     event.preventDefault();
-
     const features = map.queryRenderedFeatures(event.point, {
       layers: [clusters],
     });
@@ -249,26 +248,43 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const clusterFeature = features[0];
     const clusterId = clusterFeature.properties.cluster_id;
     const clusterCoords = clusterFeature.geometry.coordinates;
-    const currentZoom = map.getZoom();
+    const pointCount = clusterFeature.properties.point_count; // ← already available
+
+    const metersPerPixel = (156543.03392 * Math.cos((clusterCoords[1] * Math.PI) / 180)) / (2 ** map.getZoom());
+    const visibleWidthKm = (map.getCanvas().width * metersPerPixel) / 1000;
+
     const zoom = await map.getSource(id).getClusterExpansionZoom(clusterId);
 
-    if (currentZoom < CLUSTER_POPUP_MIN_ZOOM) {
+    if (visibleWidthKm > 739 || pointCount < 10) {
       map.easeTo({ center: clusterCoords, zoom });
       return;
     }
 
-    const source = map.getSource(id);
-    const leaves = await source.getClusterLeaves(clusterId, Infinity, 0);
+    const clusterPoint = map.project(clusterCoords);
+    const radius = 50;
+    const bounds = [
+      map.unproject([clusterPoint.x - radius, clusterPoint.y - radius]),
+      map.unproject([clusterPoint.x + radius, clusterPoint.y + radius]),
+    ];
 
-    const clusterDevices = leaves
-      .map((feature) => devices[feature.properties.deviceId])
+    const clusterPositions = positions.filter((pos) =>
+      pos.longitude >= bounds[0].lng &&
+      pos.longitude <= bounds[1].lng &&
+      pos.latitude <= bounds[0].lat &&
+      pos.latitude >= bounds[1].lat
+    );
+
+    const clusterDevices = clusterPositions
+      .map((pos) => devices[pos.deviceId])
       .filter(Boolean);
 
     dispatch(clustersActions.showClusterPopup({
       devices: clusterDevices,
       coordinates: clusterCoords,
     }));
-  }, [clusters, devices]);
+
+    map.easeTo({ center: clusterCoords, zoom });
+  }, [clusters, positions, devices]);
 
   useEffect(() => {
     map.addSource(id, {
@@ -372,10 +388,6 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
   useEffect(() => {
     const filtered = positions.filter((p) => Object.prototype.hasOwnProperty.call(devices, p.deviceId));
     updateAnimationState(filtered);
-    // Always push current state to the map sources. The animation loop only
-    // runs for devices that moved, so with smoothing enabled the initial
-    // positions would otherwise never reach the sources and no markers or
-    // clusters would render until something else called updateMapData.
     updateMapData();
   }, [positions, devices, enableSmoothing, updateAnimationState, updateMapData]);
 

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -13,8 +13,6 @@ import { findFonts } from './core/mapUtil';
 import { lerp, easeInOutCubic, interpolateRotation } from '../common/util/useAnimation';
 import { clustersActions } from '../store/cluster';
 
-const CLUSTER_POPUP_MIN_ZOOM = 9;
-
 // Coarser than this scale (~5 km across a typical viewport) the popup covers
 // too large an area to be meaningful, so cluster clicks zoom in instead.
 export const CLUSTER_POPUP_MAX_METERS_PER_PIXEL = 50;
@@ -254,7 +252,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const clusterFeature = features[0];
     const clusterId = clusterFeature.properties.cluster_id;
     const clusterCoords = clusterFeature.geometry.coordinates;
-    const pointCount = clusterFeature.properties.point_count; // ← already available
+    const pointCount = clusterFeature.properties.point_count;
 
     const metersPerPixel = (156543.03392 * Math.cos((clusterCoords[1] * Math.PI) / 180)) / (2 ** map.getZoom());
 

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -263,29 +263,14 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       return;
     }
 
-    const clusterPoint = map.project(clusterCoords);
-    const radius = 50;
-    const bounds = [
-      map.unproject([clusterPoint.x - radius, clusterPoint.y - radius]),
-      map.unproject([clusterPoint.x + radius, clusterPoint.y + radius]),
-    ];
-
-    const clusterPositions = positions.filter((pos) =>
-      pos.longitude >= bounds[0].lng &&
-      pos.longitude <= bounds[1].lng &&
-      pos.latitude <= bounds[0].lat &&
-      pos.latitude >= bounds[1].lat
-    );
-
-    const clusterDevices = clusterPositions
-      .map((pos) => devices[pos.deviceId])
-      .filter(Boolean);
+    const leaves = await map.getSource(id).getClusterLeaves(clusterId, Infinity, 0);
+    const clusterDevices = leaves.map((f) => devices[f.properties.deviceId]).filter(Boolean);
 
     dispatch(clustersActions.showClusterPopup({
       devices: clusterDevices,
       coordinates: clusterCoords,
     }));
-  }, [clusters, positions, devices]);
+  }, [clusters, devices]);
 
   useEffect(() => {
     map.addSource(id, {

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -19,6 +19,8 @@ const CLUSTER_POPUP_MIN_ZOOM = 9;
 // too large an area to be meaningful, so cluster clicks zoom in instead.
 export const CLUSTER_POPUP_MAX_METERS_PER_PIXEL = 50;
 
+const CLUSTER_MAX_ZOOM = 14;
+
 const TELEPORT_THRESHOLD_SQ = 0.0045 * 0.0045;
 const STALE_GAP_MS = 10000;
 const MIN_CHANGE_DEG = 0.000005;
@@ -258,7 +260,11 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
 
     const zoom = await map.getSource(id).getClusterExpansionZoom(clusterId);
 
-    if (metersPerPixel > CLUSTER_POPUP_MAX_METERS_PER_PIXEL || pointCount < 10) {
+    // Co-located devices never separate: past clusterMaxZoom the cluster only
+    // breaks into overlapping markers, so the popup is the only useful action.
+    const expandableByZooming = zoom <= CLUSTER_MAX_ZOOM;
+
+    if (expandableByZooming && (metersPerPixel > CLUSTER_POPUP_MAX_METERS_PER_PIXEL || pointCount < 10)) {
       map.easeTo({ center: clusterCoords, zoom });
       return;
     }
@@ -277,7 +283,7 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
       type: 'geojson',
       data: { type: 'FeatureCollection', features: [] },
       cluster: mapCluster,
-      clusterMaxZoom: 14,
+      clusterMaxZoom: CLUSTER_MAX_ZOOM,
       clusterRadius: 50,
     });
     map.addSource(selected, {


### PR DESCRIPTION
## Cluster click behavior

Clicking a cluster performs exactly one action — zoom **or** popup, never both:

- **Fewer than 10 devices** → zoom in (`easeTo` the cluster's expansion zoom), no popup.
- **Map zoomed out coarser than ~5 km scale** (`metersPerPixel > CLUSTER_POPUP_MAX_METERS_PER_PIXEL = 50`) → zoom in, no popup.
- **Otherwise** (10+ devices, zoomed in past the 5 km scale) → open the cluster popup, no zoom.
- **Co-located devices fallback**: the source clusters up to `CLUSTER_MAX_ZOOM = 14`. If a click would zoom but the expansion zoom exceeds that (devices at nearly identical coordinates), zooming would only produce overlapping markers, so the popup opens instead.

The popup's zoom-out auto-hide uses the same `CLUSTER_POPUP_MAX_METERS_PER_PIXEL` threshold, replacing the previous canvas-width-dependent `visibleWidthKm > 739` check in both places.

## Popup contents

Popup membership comes from the cluster source's real leaves via `getClusterLeaves(clusterId, Infinity, 0)`, replacing the 50-pixel bounding-box approximation that could include devices from neighboring clusters and miss real members.

## Cleanup

- Restored the accessible tooltip on the row's details button; removed the duplicate GPS button (it called the same handler and no distinct tracking behavior exists).
- Removed dead code (`CLUSTER_POPUP_MIN_ZOOM`, unused `ListItemText` import) and restored the explanatory comment above `updateMapData()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)